### PR TITLE
Handle missing player config gracefully

### DIFF
--- a/js/player.js
+++ b/js/player.js
@@ -93,11 +93,19 @@ export default class Player {
     }
 
     setConfigItem(configItem, default_value) {
+        if (!this.configElement) {
+            console.warn(
+                `No player config element found for ${configItem}, using default value: ${default_value}`,
+            );
+            return default_value;
+        }
         const configItemElement = this.configElement.querySelector(`.${configItem}`);
         if (configItemElement) {
             return Number(configItemElement.innerHTML);
         } else {
-            console.warn("No config element found for " + configItem + ", using default value: " + default_value);
+            console.warn(
+                `No config element found for ${configItem}, using default value: ${default_value}`,
+            );
             return default_value;
         }
     }


### PR DESCRIPTION
## Summary
- prevent crash when player `.config` element is absent by guarding `setConfigItem`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68926eae27e8832e84aca7865edf3a3c