### PR TITLE
Optimize collision bounding box calculations

### DIFF
--- a/js/collisionDetector.js
+++ b/js/collisionDetector.js
@@ -46,7 +46,8 @@ export class CollisionDetection {
         const playerRect = object.element.getBoundingClientRect();
         collisionObjects.forEach(collisionObject => {
             if (!collisionObject.enabled) return;
-            if (intersects(playerRect, collisionObject.element.getBoundingClientRect())) {
+            const collisionRect = collisionObject.element.getBoundingClientRect();
+            if (intersects(playerRect, collisionRect)) {
                 if (collisionObject.element.classList.contains('trigger')) {
                     collisionObject.trigger();
                 }
@@ -60,25 +61,29 @@ export class CollisionDetection {
         collisionObjects.forEach(collisionObject => {
             if (!collisionObject.enabled) return;
             if (collisionObject.element.classList.contains('trigger')) return;
+            const collisionRect = collisionObject.element.getBoundingClientRect();
+            const playerRectBase = {
+                left: playerRect.left + 20,
+                right: playerRect.right - 20,
+                x: playerRect.x,
+                y: playerRect.y,
+                width: playerRect.width,
+                height: playerRect.height,
+            };
             for (let i = 0.25; i < 1; i += 0.25) {
-                let playerRectNext = {
-                    left: playerRect.left + 20,
-                    right: playerRect.right - 20,
+                const playerRectNext = {
+                    ...playerRectBase,
                     top: playerRect.top + (object.velocityY * i),
                     bottom: playerRect.bottom + ((object.velocityY - object.physics.gravity) * i),
-                    x: playerRect.x,
-                    y: playerRect.y,
-                    width: playerRect.width,
-                    height: playerRect.height,
-                }
-                if (intersects(playerRectNext, collisionObject.element.getBoundingClientRect())) {
+                };
+                if (intersects(playerRectNext, collisionRect)) {
                     if (collisionObject.element.classList.contains('solid')) {
                         object.velocityY = 0;
                     }
                 }
             }
-            if (intersects(playerRect, collisionObject.element.getBoundingClientRect())) {
-                const collision = getCollisionOverlap(playerRect, collisionObject.element.getBoundingClientRect());
+            if (intersects(playerRect, collisionRect)) {
+                const collision = getCollisionOverlap(playerRect, collisionRect);
                 if (collision.bottom > 0 && collisionObject.element.classList.contains('solid')) {
                     collisionCount++;
                     this.state.bottom = collision.bottom;
@@ -93,32 +98,36 @@ export class CollisionDetection {
         });
         return collisionCount;
     }
-    
+
     checkHorizontalCollisions(object, collisionObjects) {
         const playerRect = object.element.getBoundingClientRect();
         let collisionCount = 0;
         collisionObjects.forEach(collisionObject => {
             if (!collisionObject.enabled) return;
             if (collisionObject.element.classList.contains('trigger')) return;
+            const collisionRect = collisionObject.element.getBoundingClientRect();
+            const playerRectBase = {
+                top: playerRect.top,
+                bottom: playerRect.bottom - 25,
+                x: playerRect.x,
+                y: playerRect.y,
+                width: playerRect.width,
+                height: playerRect.height,
+            };
             for (let i = 0.25; i < 1; i += 0.25) {
-                let playerRectNext = {
+                const playerRectNext = {
+                    ...playerRectBase,
                     left: playerRect.left + (object.velocityX * i),
                     right: playerRect.right + (object.velocityX * i),
-                    top: playerRect.top,
-                    bottom: playerRect.bottom - 25,
-                    x: playerRect.x,
-                    y: playerRect.y,
-                    width: playerRect.width,
-                    height: playerRect.height,
-                }
-                if (intersects(playerRectNext, collisionObject.element.getBoundingClientRect())) {
+                };
+                if (intersects(playerRectNext, collisionRect)) {
                     if (collisionObject.element.classList.contains('solid')) {
                         object.velocityX = 0;
                     }
                 }
             }
-            if (intersects(playerRect, collisionObject.element.getBoundingClientRect())) {
-                const collision = getCollisionOverlap(playerRect, collisionObject.element.getBoundingClientRect());
+            if (intersects(playerRect, collisionRect)) {
+                const collision = getCollisionOverlap(playerRect, collisionRect);
                 if (collision.left > 0 && collisionObject.element.classList.contains('solid')) {
                     this.state.left = collision.left;
                     object.x += collision.left;


### PR DESCRIPTION
## Summary
- cache collision object bounding boxes instead of repeatedly calling `getBoundingClientRect`
- compute player rect projections from a precomputed base during collision tests

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689277d08fdc832eb707579738168bdd