### PR TITLE
Cache player position displays

### DIFF
--- a/js/player.js
+++ b/js/player.js
@@ -59,6 +59,10 @@ export default class Player {
         //   Interaction
         this.interactionBox = new InteractionBox(this);
 
+        // Cached DOM references
+        this.xPositionDisplay = document.getElementById('xPositionDisplay');
+        this.yPositionDisplay = document.getElementById('yPositionDisplay');
+
         // This lets the HTML as well as the console access the player object
         window.player = this;
     }
@@ -172,8 +176,12 @@ export default class Player {
         //     grounded: this.grounded,
         //     collisionState: this.collision.state,
         // });
-        document.getElementById('xPositionDisplay').innerHTML = Math.round(this.x + this.element.getBoundingClientRect().width / 2);
-        document.getElementById('yPositionDisplay').innerHTML = Math.round(this.y + this.element.getBoundingClientRect().height / 2);
+        if (this.xPositionDisplay) {
+            this.xPositionDisplay.innerHTML = Math.round(this.x + this.element.getBoundingClientRect().width / 2);
+        }
+        if (this.yPositionDisplay) {
+            this.yPositionDisplay.innerHTML = Math.round(this.y + this.element.getBoundingClientRect().height / 2);
+        }
         if (gameInstance.debug) {
             this.element.style.outline = '3px solid red';
             this.element.style.outlineOffset = '-3px';


### PR DESCRIPTION
## Summary
- cache x/y position display elements in Player constructor
- update player position display using cached DOM nodes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689277e4e294832eae2eea5af528482e