### PR TITLE
Add null check for interaction indicator

### DIFF
--- a/js/interactionBox.js
+++ b/js/interactionBox.js
@@ -48,6 +48,9 @@ export default class InteractionBox {
         if (!gameInstance.getKeyState('E') && this.interacting) {
             this.interacting = false;
         }
+        if (!this.interactionIndicatorElement) {
+            return;
+        }
         if (intersects) {
             this.interactionIndicatorElement.style.visibility = 'visible';
         } else {


### PR DESCRIPTION
## Summary
- Avoid accessing interaction indicator style when it doesn't exist

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689277f57258832e817ce7eb26c7f3c7