### PR TITLE
Use class-based grid sizing for levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A browser-based platformer engine built with plain JavaScript, HTML and CSS. Lev
 
 ```html
 <div id="viewport">
-  <div class="level" id="level-one">
+  <div class="level grid-1x1" id="level-one">
     <div class="screen">
       <div id="player">
         <div id="interactionBox"></div>
@@ -48,6 +48,7 @@ A browser-based platformer engine built with plain JavaScript, HTML and CSS. Lev
 </div>
 ```
 
+* Grid dimensions are defined on the `.level` element via a `grid-colsxrows` class.
 * Out-of-bounds behavior is controlled by classes on the `.level` element such as `contain`, `respawn` or `wrap` with optional direction suffixes (e.g. `wrap-vert`).
 * Player spawn can be set via URL query parameters `?spawn_x=` and `?spawn_y=`.
 * Filters and camera behavior are controlled with classes on `#viewport` (e.g. `no-follow`, `scroll-bar`).

--- a/html/hub.html
+++ b/html/hub.html
@@ -31,7 +31,7 @@
     <span class="cross debug"></span>
 
     <div class="tv" id="viewport">
-        <div class="level 3x2 contain" id="level-one">
+        <div class="level contain grid-3x2" id="level-one">
             <div class="screen">
                 <div class="cat" id="player">
                     <div class="interaction-indicator question-indicator">?</div>

--- a/html/platformer.html
+++ b/html/platformer.html
@@ -31,7 +31,7 @@
     <span class="cross debug"></span>
 
     <div class="tv" id="viewport">
-        <div class="level 3x3 wrap-vert contain-hori" id="level-one">
+        <div class="level wrap-vert contain-hori grid-3x3" id="level-one">
             <div class="screen">
                 <div class="cat" id="player">
                     <div class="interaction-indicator question-indicator">?</div>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
   <span class="cross debug"></span>
 
   <div id="viewport">
-    <div class="level 3x1 contain" id="level-one">
+    <div class="level contain grid-3x1" id="level-one">
       <div class="screen">
         <div class="cat" id="player">
           <div class="interaction-indicator question-indicator">?</div>

--- a/js/level.js
+++ b/js/level.js
@@ -82,27 +82,27 @@ export default class Level {
     }
 
     initScreenGrid() {
-        const classes = this.element.classList;
-        let doDefault = true;
-        for (let i = 0; i < classes.length; i++) {
-            // This needs to be more nuanced, as it will match any class with an x in it 🐢💭
-            if (classes[i].includes('x')) {
-                doDefault = false;
-                const gridValues = classes[i].split('x');
-                this.columns = gridValues[0];
-                this.rows = gridValues[1];
+        const gridClass = Array.from(this.element.classList).find(className => /^grid-\d+x\d+$/.test(className));
+
+        if (gridClass) {
+            const match = gridClass.match(/^grid-(\d+)x(\d+)$/);
+            if (match) {
+                this.columns = parseInt(match[1], 10);
+                this.rows = parseInt(match[2], 10);
                 this.element.style.display = 'grid';
                 this.element.style.position = 'relative';
                 this.element.style.gridTemplateColumns = `repeat(${this.columns}, var(--screen-width))`;
                 this.element.style.gridTemplateRows = `repeat(${this.rows}, var(--screen-height))`;
                 this.element.style.width = "max-content";
+                return;
+            } else {
+                console.warn(`Invalid grid class "${gridClass}"`);
             }
         }
-        if (doDefault) {
-            console.warn("No grid dimensions specified, using linear grid layout");
-            this.element.style.gridTemplateColumns = `repeat(${this.screens.length}, var(--screen-width))`;
-            this.element.style.gridTemplateRows = `var(--screen-height)`;
-        }
+
+        console.warn("No grid dimensions specified, using linear grid layout");
+        this.element.style.gridTemplateColumns = `repeat(${this.screens.length}, var(--screen-width))`;
+        this.element.style.gridTemplateRows = `var(--screen-height)`;
     }
 
     initScreens() {


### PR DESCRIPTION
## Summary
- Parse grid dimensions from a `grid-<cols>x<rows>` class instead of a `data-grid` attribute
- Update HTML examples to specify grid size with `grid-<cols>x<rows>` classes
- Document class-based grid configuration in the README

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6894ceb46934832e9a73bca466e1e069