### PR TITLE
feat: add broadcast listeners

### DIFF
--- a/js/broadcastManager.js
+++ b/js/broadcastManager.js
@@ -1,14 +1,18 @@
 class BroadcastManager {
     constructor() {
         this.broadcasts = {};
+        this.listeners = {};
     }
 
     broadcastSignal(channel, signal) {
         this.broadcasts[channel] = signal;
+        if (this.listeners[channel]) {
+            this.listeners[channel].forEach(callback => callback(signal));
+        }
     }
 
     broadcastSignalForDuration(channel, signal, duration) {
-        this.broadcasts[channel] = signal;
+        this.broadcastSignal(channel, signal);
         setTimeout(() => {
             this.stopBroadcast(channel);
         }, duration);
@@ -20,6 +24,19 @@ class BroadcastManager {
 
     checkBroadcast(channel) {
         return this.broadcasts[channel];
+    }
+
+    addListener(channel, callback) {
+        if (!this.listeners[channel]) {
+            this.listeners[channel] = new Set();
+        }
+        this.listeners[channel].add(callback);
+    }
+
+    removeListener(channel, callback) {
+        if (this.listeners[channel]) {
+            this.listeners[channel].delete(callback);
+        }
     }
 }
 

--- a/js/camera.js
+++ b/js/camera.js
@@ -30,6 +30,7 @@ export default class Camera {
         this.minOffset = this.offsetBounds;
         this.lookahead = 0.05;
         this.initStyles();
+        this.initFilters();
     }
 
     positionOverlay() {

--- a/js/elementStateManagers.js
+++ b/js/elementStateManagers.js
@@ -74,6 +74,21 @@ export default class ToggleManager {
     getState() {
         return this.toggledOn;
     }
+
+    listenToBroadcast(channel, onSignal = 'on', offSignal = 'off') {
+        gameInstance.signalManager.addListener(channel, (signal) => {
+            if (signal === onSignal && !this.toggledOn) {
+                this.toggledOn = true;
+                this.on_element.style.visibility = 'visible';
+                this.off_element.style.visibility = 'hidden';
+            }
+            if (signal === offSignal && this.toggledOn) {
+                this.toggledOn = false;
+                this.on_element.style.visibility = 'hidden';
+                this.off_element.style.visibility = 'visible';
+            }
+        });
+    }
 }
 
 export class MultiStateManager {
@@ -101,10 +116,11 @@ export class MultiStateManager {
         return this.currentState;
     }
 
-    syncStateToBroadcast(channel) {
-        const state = gameInstance.signalManager.checkBroadcast(channel);
-        if (state) {
-            this.setState(state);
-        }
+    listenToBroadcast(channel) {
+        gameInstance.signalManager.addListener(channel, (signal) => {
+            if (signal) {
+                this.setState(signal);
+            }
+        });
     }
 }

--- a/js/game.js
+++ b/js/game.js
@@ -6,12 +6,8 @@ class Game {
     constructor() {
         this.player = null;
         this.level = null;
-        this.camera = new Camera();
+        this.camera = null;
         this.pauseElement = document.getElementById('pause');
-        if (this.pauseElement) {
-            this.camera.overlayElement.appendChild(this.pauseElement);
-            this.initPauseElement();
-        }
 
         this.debug = false;
         this.paused = false;
@@ -91,6 +87,11 @@ class Game {
     }
 
     start() {
+        this.camera = new Camera();
+        if (this.pauseElement) {
+            this.camera.overlayElement.appendChild(this.pauseElement);
+            this.initPauseElement();
+        }
         requestAnimationFrame(this.update.bind(this));
         this.initKeyStateListeners();
         this.player.start();

--- a/js/levelObjects.js
+++ b/js/levelObjects.js
@@ -157,6 +157,7 @@ export class Reciever extends LevelObject{
             })
         });
         this.stateManager = new MultiStateManager(element, this.signals, this.signals[0]);
+        this.stateManager.listenToBroadcast(this.broadcastChannel);
     }
 
     update() {
@@ -165,7 +166,6 @@ export class Reciever extends LevelObject{
         } else {
             this.element.style.outline = 'none';
         }
-        this.stateManager.syncStateToBroadcast(this.broadcastChannel);
     }
 
 }


### PR DESCRIPTION
## Summary
- add listener registry to `BroadcastManager` and notify callbacks on broadcast
- allow `ToggleManager` and `MultiStateManager` to subscribe to channels
- update `Reciever` to react to signals via listeners

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6894cecf4f00832eb98aef34f8491214