### PR TITLE
Decouple Camera from Game instance

### DIFF
--- a/js/camera.js
+++ b/js/camera.js
@@ -1,8 +1,7 @@
-import gameInstance from "./game.js";
 import { Reciever } from "./levelObjects.js";
 
 export default class Camera {
-    constructor() {
+    constructor(player = null, keyState = null, debugProvider = () => false) {
         this.element = document.getElementById('viewport');
         this.overlayElement = document.getElementById('overlay');
         if (!this.overlayElement) {
@@ -30,6 +29,11 @@ export default class Camera {
         this.minOffset = this.offsetBounds;
         this.lookahead = 0.05;
         this.initStyles();
+
+        // References to game dependencies
+        this.player = player;
+        this.keyState = keyState;
+        this.debugProvider = debugProvider;
     }
 
     positionOverlay() {
@@ -59,13 +63,25 @@ export default class Camera {
 
     }
 
+    setPlayer(player) {
+        this.player = player;
+    }
+
+    setInput(keyState) {
+        this.keyState = keyState;
+    }
+
+    setDebugProvider(debugProvider) {
+        this.debugProvider = debugProvider;
+    }
+
     update() {
         if (this.followPlayer) this.trackPlayer();
         if (this.filterReciever) this.filterReciever.update();
         this.processInput();
         this.applyMaxOffset();
         this.positionOverlay();
-        if (gameInstance && gameInstance.debug) this.element.style.overflow = "auto";
+        if (this.debugProvider && this.debugProvider()) this.element.style.overflow = "auto";
         else {
             if (this.element.classList.contains('scroll-bar')) this.element.style.overflow = 'auto';
             else this.element.style.overflow = 'hidden';
@@ -73,10 +89,11 @@ export default class Camera {
     }
 
     trackPlayer() {
+        if (!this.player) return;
         let currentX = this.element.scrollLeft;
         let currentY = this.element.scrollTop;
-        this.targetX = (gameInstance.player.x + (gameInstance.player.element.getBoundingClientRect().width / 2)) - (this.element.getBoundingClientRect().width - 80) * this.offsetX;
-        this.targetY = (gameInstance.player.y + (gameInstance.player.element.getBoundingClientRect().height / 2)) - (this.element.getBoundingClientRect().height - 80) * this.offsetY;
+        this.targetX = (this.player.x + (this.player.element.getBoundingClientRect().width / 2)) - (this.element.getBoundingClientRect().width - 80) * this.offsetX;
+        this.targetY = (this.player.y + (this.player.element.getBoundingClientRect().height / 2)) - (this.element.getBoundingClientRect().height - 80) * this.offsetY;
 
         this.element.scrollTo(
             currentX + (this.targetX - currentX) * this.smoothing,
@@ -85,29 +102,31 @@ export default class Camera {
     }
 
     snapToPlayer() {
+        if (!this.player) return;
         this.followPlayer = false;
         this.element.scrollTo(
-            (gameInstance.player.x + (gameInstance.player.element.getBoundingClientRect().width / 2)) - (this.element.getBoundingClientRect().width - 80) * this.offsetX,
-            (gameInstance.player.y + (gameInstance.player.element.getBoundingClientRect().height / 2)) - (this.element.getBoundingClientRect().height - 80) * this.offsetY
+            (this.player.x + (this.player.element.getBoundingClientRect().width / 2)) - (this.element.getBoundingClientRect().width - 80) * this.offsetX,
+            (this.player.y + (this.player.element.getBoundingClientRect().height / 2)) - (this.element.getBoundingClientRect().height - 80) * this.offsetY
         );
         this.followPlayer = true;
     }
 
     processInput() {
-        if (gameInstance.keyState['ARROWUP']) {
+        if (!this.keyState) return;
+        if (this.keyState['ARROWUP']) {
             this.offsetY += 0.01;
         }
-        if (gameInstance.keyState['ARROWDOWN']) {
+        if (this.keyState['ARROWDOWN']) {
             this.offsetY -= 0.01;
         }
-        if (gameInstance.keyState['ARROWLEFT']) {
+        if (this.keyState['ARROWLEFT']) {
             this.offsetX += 0.01;
         }
-        if (gameInstance.keyState['ARROWRIGHT']) {
+        if (this.keyState['ARROWRIGHT']) {
             this.offsetX -= 0.01;
         }
 
-        if (!gameInstance.keyState['ARROWUP'] && !gameInstance.keyState['ARROWDOWN'] && !gameInstance.keyState['ARROWLEFT'] && !gameInstance.keyState['ARROWRIGHT']) {
+        if (!this.keyState['ARROWUP'] && !this.keyState['ARROWDOWN'] && !this.keyState['ARROWLEFT'] && !this.keyState['ARROWRIGHT']) {
             this.applyCenterDrift();
         }
     }
@@ -120,8 +139,9 @@ export default class Camera {
     }
 
     applyCenterDrift() {
-        if (this.offsetX != (this.restingOffsetX + (gameInstance.player.facingRight() ? -this.lookahead : this.lookahead))) {
-            if (this.offsetX > (this.restingOffsetX + (gameInstance.player.facingRight() ? -this.lookahead : this.lookahead))) {
+        if (!this.player) return;
+        if (this.offsetX != (this.restingOffsetX + (this.player.facingRight() ? -this.lookahead : this.lookahead))) {
+            if (this.offsetX > (this.restingOffsetX + (this.player.facingRight() ? -this.lookahead : this.lookahead))) {
                 this.offsetX -= 0.01;
             } else {
                 this.offsetX += 0.01;

--- a/js/game.js
+++ b/js/game.js
@@ -6,16 +6,11 @@ class Game {
     constructor() {
         this.player = null;
         this.level = null;
-        this.camera = new Camera();
-        this.pauseElement = document.getElementById('pause');
-        if (this.pauseElement) {
-            this.camera.overlayElement.appendChild(this.pauseElement);
-            this.initPauseElement();
-        }
 
         this.debug = false;
         this.paused = false;
         this.processedInput = false;
+
         // New input processor/keyState system
         // https://chatgpt.com/c/f5c9ad3a-6d67-40eb-b2a6-9dc3d5afcff0
         this.keyState = {
@@ -32,6 +27,13 @@ class Game {
             ARROWRIGHT: false,
             ESCAPE: false
         };
+
+        this.camera = new Camera(this.player, this.keyState, () => this.debug);
+        this.pauseElement = document.getElementById('pause');
+        if (this.pauseElement) {
+            this.camera.overlayElement.appendChild(this.pauseElement);
+            this.initPauseElement();
+        }
 
         this.signalManager = new BroadcastManager();
 
@@ -61,6 +63,7 @@ class Game {
 
     setPlayer(player) {
         this.player = player;
+        this.camera.setPlayer(player);
     }
 
     getPlayer() {


### PR DESCRIPTION
## Summary
- Inject player and input references into `Camera` instead of importing the game instance.
- Initialize `Camera` in `Game` with player and input objects and propagate player updates.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/camera.js js/game.js`


------
https://chatgpt.com/codex/tasks/task_b_6894cedff9dc832e97b47e3b40c0f3b8