### PR TITLE
feat: centralize keyboard input handling

### DIFF
--- a/js/camera.js
+++ b/js/camera.js
@@ -94,20 +94,25 @@ export default class Camera {
     }
 
     processInput() {
-        if (gameInstance.keyState['ARROWUP']) {
+        if (gameInstance.inputManager.isKeyActive('ArrowUp')) {
             this.offsetY += 0.01;
         }
-        if (gameInstance.keyState['ARROWDOWN']) {
+        if (gameInstance.inputManager.isKeyActive('ArrowDown')) {
             this.offsetY -= 0.01;
         }
-        if (gameInstance.keyState['ARROWLEFT']) {
+        if (gameInstance.inputManager.isKeyActive('ArrowLeft')) {
             this.offsetX += 0.01;
         }
-        if (gameInstance.keyState['ARROWRIGHT']) {
+        if (gameInstance.inputManager.isKeyActive('ArrowRight')) {
             this.offsetX -= 0.01;
         }
 
-        if (!gameInstance.keyState['ARROWUP'] && !gameInstance.keyState['ARROWDOWN'] && !gameInstance.keyState['ARROWLEFT'] && !gameInstance.keyState['ARROWRIGHT']) {
+        if (
+            !gameInstance.inputManager.isKeyActive('ArrowUp') &&
+            !gameInstance.inputManager.isKeyActive('ArrowDown') &&
+            !gameInstance.inputManager.isKeyActive('ArrowLeft') &&
+            !gameInstance.inputManager.isKeyActive('ArrowRight')
+        ) {
             this.applyCenterDrift();
         }
     }

--- a/js/game.js
+++ b/js/game.js
@@ -1,6 +1,6 @@
 import Camera, { Filter } from './camera.js';
 import BroadcastManager from './broadcastManager.js';
-import { debugLog } from './tools.js';
+import InputManager from './inputManager.js';
 
 class Game {
     constructor() {
@@ -16,23 +16,8 @@ class Game {
         this.debug = false;
         this.paused = false;
         this.processedInput = false;
-        // New input processor/keyState system
-        // https://chatgpt.com/c/f5c9ad3a-6d67-40eb-b2a6-9dc3d5afcff0
-        this.keyState = {
-            W: false,
-            A: false,
-            S: false,
-            D: false,
-            SHIFT: false,
-            SPACE: false,
-            CONTROL: false,
-            ARROWUP: false,
-            ARROWDOWN: false,
-            ARROWLEFT: false,
-            ARROWRIGHT: false,
-            ESCAPE: false
-        };
 
+        this.inputManager = new InputManager();
         this.signalManager = new BroadcastManager();
 
         window.game = this;
@@ -55,10 +40,6 @@ class Game {
         });
     }
 
-    getKeyState(key) {
-        return this.keyState[key];
-    }
-
     setPlayer(player) {
         this.player = player;
     }
@@ -71,51 +52,30 @@ class Game {
         this.level = level;
     }
 
-    initKeyStateListeners() {
-        document.addEventListener('keydown', (event) => {
-            if (this.keyState['SHIFT'] && this.keyState['CONTROL']) {
-                return;
-            }
-            event.preventDefault();
-            let key = event.key.toUpperCase();
-            if (event.key == " ") key = "SPACE";
-            debugLog(key);
-            this.keyState[key] = true;
-        });
-
-        document.addEventListener('keyup', (event) => {
-            let key = event.key.toUpperCase();
-            if (event.key == " ") key = "SPACE";
-            this.keyState[key] = false;
-        });
-    }
-
     start() {
         requestAnimationFrame(this.update.bind(this));
-        this.initKeyStateListeners();
         this.player.start();
     }
 
     update() {
         this.processInput();
         if (!this.paused) {
-            this.player.update(this.keyState);
+            this.player.update();
             this.level.update();
             this.camera.update();
         }
-
 
         requestAnimationFrame(this.update.bind(this));
     }
 
     processInput() {
-        if (this.keyState['3'] && !this.processedInput) {
+        if (this.inputManager.isKeyActive('Digit3') && !this.processedInput) {
             this.processedInput = true;
             this.toggleDebug();
-        } else if (this.keyState['ESCAPE'] && !this.processedInput) {
+        } else if (this.inputManager.isKeyActive('Escape') && !this.processedInput) {
             this.processedInput = true;
             if (this.pauseElement) this.togglePause();
-        } else if (!this.keyState['ESCAPE'] && !this.keyState['3']) {
+        } else if (!this.inputManager.isKeyActive('Escape') && !this.inputManager.isKeyActive('Digit3')) {
             this.processedInput = false;
         }
     }

--- a/js/inputManager.js
+++ b/js/inputManager.js
@@ -1,0 +1,40 @@
+class InputManager {
+    constructor() {
+        this.activeKeys = new Map();
+        this.subscribers = {
+            keydown: new Set(),
+            keyup: new Set(),
+        };
+
+        document.addEventListener('keydown', (event) => {
+            this.activeKeys.set(event.code, true);
+            this._notify('keydown', event);
+        });
+
+        document.addEventListener('keyup', (event) => {
+            this.activeKeys.set(event.code, false);
+            this._notify('keyup', event);
+        });
+    }
+
+    _notify(type, event) {
+        if (!this.subscribers[type]) return;
+        this.subscribers[type].forEach((callback) => callback(event));
+    }
+
+    isKeyActive(code) {
+        return this.activeKeys.get(code) || false;
+    }
+
+    subscribe(type, callback) {
+        if (!this.subscribers[type]) return;
+        this.subscribers[type].add(callback);
+    }
+
+    unsubscribe(type, callback) {
+        if (!this.subscribers[type]) return;
+        this.subscribers[type].delete(callback);
+    }
+}
+
+export default InputManager;

--- a/js/interactionBox.js
+++ b/js/interactionBox.js
@@ -34,9 +34,9 @@ export default class InteractionBox {
             if (top || right || bottom || left) {
                 intersects = true;
             }
-            if ((top || right || bottom || left) && gameInstance.getKeyState('E') && !this.interacting) {
+            if ((top || right || bottom || left) && gameInstance.inputManager.isKeyActive('KeyE') && !this.interacting) {
                 interactions.push(interactable);
-            } 
+            }
         }
         if (interactions.length > 0) {
             this.interacting = true;
@@ -45,7 +45,7 @@ export default class InteractionBox {
                 interactable.interact();
             });
         } 
-        if (!gameInstance.getKeyState('E') && this.interacting) {
+        if (!gameInstance.inputManager.isKeyActive('KeyE') && this.interacting) {
             this.interacting = false;
         }
         if (!this.interactionIndicatorElement) {

--- a/js/player.js
+++ b/js/player.js
@@ -219,26 +219,29 @@ export default class Player {
     }
 
     processInput() {
-        if (gameInstance.keyState['SHIFT'] && this.grounded) {
+        const input = gameInstance.inputManager;
+        const shift = input.isKeyActive('ShiftLeft') || input.isKeyActive('ShiftRight');
+
+        if (shift && this.grounded) {
             this.physics.acceleration = this.sprintAcceleration;
             this.physics.maxVelocity = this.sprintMaxVelocity;
-        } else if (!gameInstance.keyState['SHIFT'] && this.grounded) {
+        } else if (!shift && this.grounded) {
             this.physics.acceleration = this.acceleration;
             this.physics.maxVelocity = this.maxVelocity;
         }
 
         // Movement calculations here
-        if (gameInstance.keyState['A']) {
+        if (input.isKeyActive('KeyA')) {
             this.lookLeft();
             this.physics.move(this, -this.physics.acceleration, 0);
         }
-        if (gameInstance.keyState['D']) {
+        if (input.isKeyActive('KeyD')) {
             this.lookRight();
             this.physics.move(this, this.physics.acceleration, 0);
         }
-        if (gameInstance.keyState['S']) this.velocityY += this.physics.acceleration;
+        if (input.isKeyActive('KeyS')) this.velocityY += this.physics.acceleration;
         // Similar for other directions
-        if (gameInstance.keyState['W'] || gameInstance.keyState['SPACE']) {
+        if (input.isKeyActive('KeyW') || input.isKeyActive('Space')) {
             this.jump();
         } else {
             this.jumpProcessed = false; // Reset the flag when 'W' is not pressed
@@ -248,7 +251,7 @@ export default class Player {
                 this.physics.gravity = this.gravity;
             }
         }
-        if (gameInstance.keyState['R']) {
+        if (input.isKeyActive('KeyR')) {
             this.respawnAtCheckpoint();
         }
     }
@@ -285,8 +288,10 @@ export default class Player {
     }
 
     applyAnimations() {
-        if (Math.abs(this.velocityX) > 0 && gameInstance.keyState['SHIFT']) this.animationManager.changeAnimation('run');
-        else if (Math.abs(this.velocityX) > 0 && (gameInstance.keyState['A'] || gameInstance.keyState['D'])) this.animationManager.changeAnimation('walk');
+        const input = gameInstance.inputManager;
+        const shift = input.isKeyActive('ShiftLeft') || input.isKeyActive('ShiftRight');
+        if (Math.abs(this.velocityX) > 0 && shift) this.animationManager.changeAnimation('run');
+        else if (Math.abs(this.velocityX) > 0 && (input.isKeyActive('KeyA') || input.isKeyActive('KeyD'))) this.animationManager.changeAnimation('walk');
         else if (this.grounded) this.animationManager.changeAnimation('idle');
         else this.animationManager.changeAnimation('jump');
     }


### PR DESCRIPTION
## Summary
- add InputManager to track active keys and handle subscriptions
- refactor Game, Player, Camera, and InteractionBox to query InputManager for key states

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_b_6894cef384c0832e9c81196177e7219a