### PR TITLE
Add HTML dialogue system with example tree

### DIFF
--- a/css/dialogue.css
+++ b/css/dialogue.css
@@ -1,0 +1,40 @@
+#dialogue-container {
+  position: fixed;
+  bottom: 5%;
+  left: 10%;
+  width: 80%;
+  display: none;
+  z-index: 1000;
+}
+#dialogue-box {
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  padding: 1rem;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+}
+#dialogue-box.narrator {
+  background: #222;
+  font-style: italic;
+}
+#dialogue-box.npc {
+  background: #003;
+  border: 2px solid #55f;
+}
+#dialogue-content {
+  min-height: 60px;
+}
+#dialogue-choices button,
+#dialogue-choices a {
+  display: block;
+  margin-top: 0.5rem;
+  background: #555;
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+}
+#dialogue-choices button:hover,
+#dialogue-choices a:hover {
+  background: #777;
+}

--- a/index.html
+++ b/index.html
@@ -24,7 +24,9 @@
     <link rel="stylesheet" href="./css/index.css" />
     <link rel="stylesheet" href="./css/hexBackground.css" />
     <link rel="stylesheet" href="./css/global.css" />
+    <link rel="stylesheet" href="./css/dialogue.css" />
     <script src="./js/hexBackground.js" defer></script>
+    <script type="module" src="./js/dialogue.js" defer></script>
     <title>Piinro's Platformer</title>
   </head>
 
@@ -75,6 +77,47 @@
             Right now it's missing a lot, but I plan to make this the primary
             way to view my site!<br />
             Thank you for checking out my project! <br />
+          </div>
+
+          <div
+            id="npc-1"
+            class="object interactable clickable npc"
+            style="width: 50px; height: 50px; background: url('./img/cat_stand.gif') no-repeat center/contain;"
+            data-dialog-start="intro"
+            onclick="dialogue.start(this)"
+          >
+            <template id="intro" data-style="narrator" data-advance="word">
+              <p>You stand at a crossroads. Where do you go?</p>
+              <button class="choice" data-next="forest">Enter the forest</button>
+              <button class="choice" data-next="town">Head to town</button>
+              <button class="choice" data-next="camp">Set up camp</button>
+            </template>
+            <template id="forest" data-style="npc" data-advance="character">
+              <p>The forest is dark and quiet.</p>
+              <button class="choice" data-next="forestEnd">Press on</button>
+              <button class="choice" data-next="intro">Retreat to the crossroads</button>
+            </template>
+            <template id="town" data-style="npc" data-advance="character">
+              <p>The town is bustling with traders.</p>
+              <button class="choice" data-next="townEnd">Talk to the locals</button>
+              <button class="choice" data-next="intro">Leave for the crossroads</button>
+            </template>
+            <template id="camp" data-style="narrator" data-advance="instant">
+              <p>You rest at the camp. Dawn approaches.</p>
+              <button class="choice" data-next="intro">Break camp</button>
+            </template>
+            <template id="forestEnd" data-style="npc" data-advance="instant">
+              <p>
+                You discover hidden treasure deep in the woods. The adventure
+                ends!
+              </p>
+            </template>
+            <template id="townEnd" data-style="npc" data-advance="instant">
+              <p>
+                You settle into town life, finding a new home among its people.
+                The adventure ends!
+              </p>
+            </template>
           </div>
 
           <div class="object-label debug">Room 1</div>
@@ -192,6 +235,13 @@
           X: <span id="xPositionDisplay">x</span> Y:
           <span id="yPositionDisplay">y</span>
         </h1>
+      </div>
+    </div>
+
+    <div id="dialogue-container">
+      <div id="dialogue-box" class="narrator">
+        <div id="dialogue-content"></div>
+        <div id="dialogue-choices"></div>
       </div>
     </div>
   </body>

--- a/js/dialogue.js
+++ b/js/dialogue.js
@@ -1,0 +1,106 @@
+class DialogueSystem {
+  constructor() {
+    this.container = document.getElementById('dialogue-container');
+    this.box = document.getElementById('dialogue-box');
+    this.content = document.getElementById('dialogue-content');
+    this.choices = document.getElementById('dialogue-choices');
+    this.templates = new Map();
+    this.revealTimer = null;
+    this.currentNode = null;
+    document.addEventListener('keydown', e => {
+      if (e.key === 'e' || e.key === 'E') {
+        this.handleInteract();
+      }
+    });
+  }
+
+  start(root) {
+    const startId = root.dataset.dialogStart;
+    if (!startId) return;
+    this.templates.clear();
+    root.querySelectorAll('template').forEach(t => {
+      this.templates.set(t.id, t);
+    });
+    this.container.style.display = 'block';
+    this.renderNode(startId);
+  }
+
+  handleInteract() {
+    if (!this.currentNode) return;
+    if (this.revealing) {
+      clearInterval(this.revealTimer);
+      this.content.innerHTML = this.fullText;
+      this.revealing = false;
+      this.showChoices();
+      return;
+    }
+    const next = this.currentNode.dataset.next;
+    if (next) {
+      this.renderNode(next);
+    } else if (this.choices.children.length === 0) {
+      this.close();
+    }
+  }
+
+  renderNode(id) {
+    const tpl = this.templates.get(id);
+    if (!tpl) return;
+    this.currentNode = tpl;
+    this.box.className = tpl.dataset.style || '';
+    const clone = tpl.content.cloneNode(true);
+    this.content.innerHTML = '';
+    this.choices.innerHTML = '';
+    this.fullText = clone.querySelector('p') ? clone.querySelector('p').innerHTML : clone.textContent;
+    const advance = tpl.dataset.advance || 'instant';
+    this.revealText(this.fullText, advance);
+    clone.querySelectorAll('.choice').forEach(choice => {
+      choice.addEventListener('click', () => {
+        this.renderNode(choice.dataset.next);
+      });
+      this.choices.appendChild(choice);
+    });
+    if (clone.querySelector('.choice')) {
+      this.choices.style.display = 'none';
+    } else {
+      this.choices.style.display = 'block';
+    }
+  }
+
+  revealText(text, mode) {
+    this.revealing = true;
+    this.content.innerHTML = '';
+    if (mode === 'instant') {
+      this.content.innerHTML = text;
+      this.revealing = false;
+      this.showChoices();
+      return;
+    }
+    const parts = mode === 'word' ? text.split(/(\s+)/) : text.split('');
+    let i = 0;
+    this.revealTimer = setInterval(() => {
+      this.content.innerHTML += parts[i];
+      i++;
+      if (i >= parts.length) {
+        clearInterval(this.revealTimer);
+        this.revealing = false;
+        this.showChoices();
+      }
+    }, 50);
+  }
+
+  showChoices() {
+    this.choices.style.display = 'block';
+    if (this.choices.children.length === 0) {
+      // no choices and no explicit next: close on interact
+      this.currentNode.dataset.next = '';
+    }
+  }
+
+  close() {
+    this.container.style.display = 'none';
+    this.currentNode = null;
+  }
+}
+
+window.dialogue = new DialogueSystem();
+export default window.dialogue;


### PR DESCRIPTION
## Summary
- implement dialogue system controlled entirely by HTML and CSS
- add simple NPC trigger in the platformer level
- include sample branching dialogue tree with loops and two endings
- nest dialogue templates inside the NPC element for a more object-oriented structure

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a8c62b7890832ebf22b4d95aab1f4f