### PR TITLE
Refactor inventory with template-backed items and event-driven HUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,6 @@
   <body class="hexBackground">
     <span class="criss debug"></span>
     <span class="cross debug"></span>
-
     <div id="viewport">
       <div class="level 3x1 contain" id="level-one">
         <div class="screen">
@@ -106,36 +105,9 @@
           <div
             class="object pickup on-touch respawn"
             id="mushroom"
+            data-template="item-shroom"
             onclick="console.log('picked up mushroom')"
-          >
-            <div
-              class="item name-shroom"
-              onclick="console.log('used mushroom')"
-            >
-              <div class="iconElement shroom-icon"></div>
-              <span class="inspectElement mushroom-inspect">
-                <h2>This is the dev mushroom</h2>
-                <p>Click the button below to toggle the broadcast on or off</p>
-                <button
-                  onclick="
-                  console.log('awooga')
-                  const broadcastValue = game.signalManager.checkBroadcast('toggle_two');
-                  if (broadcastValue === 'on') {
-                    game.signalManager.broadcastSignal('toggle_two', 'off');
-                  } else {
-                    game.signalManager.broadcastSignal('toggle_two', 'on');
-                  }
-                "
-                >
-                  Toggle Broadcast
-                </button>
-              </span>
-              <span class="description">
-                A mushroom that a plumber told you would increase your size
-              </span>
-              <span class="count">1</span>
-            </div>
-          </div>
+          ></div>
         </div>
         <div class="screen">
           <div class="object-label debug">Room 2</div>

--- a/items.html
+++ b/items.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Item Definitions</title>
+    <link rel="stylesheet" href="./css/global.css" />
+  </head>
+  <body>
+    <h1>Item Definitions</h1>
+
+    <template id="item-shroom">
+      <div class="item name-shroom" onclick="console.log('used mushroom')">
+        <div class="iconElement shroom-icon"></div>
+        <span class="inspectElement mushroom-inspect">
+          <h2>This is the dev mushroom</h2>
+          <p>Click the button below to toggle the broadcast on or off</p>
+          <button
+            onclick="
+                  console.log('awooga')
+                  const broadcastValue = game.signalManager.checkBroadcast('toggle_two');
+                  if (broadcastValue === 'on') {
+                    game.signalManager.broadcastSignal('toggle_two', 'off');
+                  } else {
+                    game.signalManager.broadcastSignal('toggle_two', 'on');
+                  }
+                "
+          >
+            Toggle Broadcast
+          </button>
+        </span>
+        <span class="description">
+          A mushroom that a plumber told you would increase your size
+        </span>
+        <span class="count">1</span>
+      </div>
+    </template>
+
+    <div id="item-demo" class="item-demo"></div>
+
+    <script type="module">
+      import { renderItemDemos } from './js/itemTemplates.js';
+      renderItemDemos(document.getElementById('item-demo'));
+    </script>
+  </body>
+</html>

--- a/js/game.js
+++ b/js/game.js
@@ -125,7 +125,7 @@ class Game {
         if (this.paused) {
             this.pauseElement.style.visibility = 'visible';
             this.pauseElement.style.pointerEvents = 'all';
-            this.player.inventory.HUD.syncInventoryMenu();
+            this.player.HUD.syncInventoryMenu();
         } else {
             this.pauseElement.style.visibility = 'hidden';
             this.pauseElement.style.pointerEvents = 'none';

--- a/js/hud.js
+++ b/js/hud.js
@@ -1,0 +1,267 @@
+import gameInstance from "./game.js";
+
+export default class HUD {
+  constructor(inventory) {
+    this.inventory = inventory;
+    this.HUD = {};
+    this.initialize();
+
+    this.inventory.on('itemAdded', () => {
+      this.syncCounts();
+      this.setIcons();
+    });
+    this.inventory.on('itemRemoved', () => {
+      this.syncCounts();
+      this.setIcons();
+    });
+    this.inventory.on('itemModified', () => {
+      this.syncCounts();
+      this.setIcons();
+    });
+  }
+
+  initialize() {
+    this.mapHudElements();
+    this.syncCounts();
+    this.setIcons();
+  }
+
+  mapHudElements() {
+    let elements = document.querySelectorAll(".hud-item");
+    let itemsList = [];
+    let hudElements = {};
+    for (let i = 0; i < elements.length; i++) {
+      const element = elements[i];
+      for (let j = 0; j < element.classList.length; j++) {
+        const className = element.classList[j];
+        if (className.startsWith("hud-") && className !== "hud-item") {
+          const tag = className.split("-")[1];
+          itemsList.push(tag);
+        }
+        if (className.startsWith("hud-") && className !== "hud-item") {
+          const tag = className.replace("hud-", "");
+          hudElements[tag] = element;
+        }
+      }
+    }
+    for (let i = 0; i < itemsList.length; i++) {
+      const item = itemsList[i];
+      for (let j = 0; j < Object.keys(hudElements).length; j++) {
+        const element = hudElements[Object.keys(hudElements)[j]];
+        for (let k = 0; k < element.classList.length; k++) {
+          const className = element.classList[k];
+          if (className.includes(item)) {
+            if (this.HUD[item] === undefined) {
+              this.HUD[item] = [element];
+            } else {
+              this.HUD[item].push(element);
+            }
+          }
+        }
+      }
+      // clear duplicates from this.HUD[item]
+      if (this.HUD[item] !== undefined) {
+        this.HUD[item] = [...new Set(this.HUD[item])];
+      }
+    }
+  }
+
+  setIcons() {
+    for (let i = 0; i < Object.keys(this.HUD).length; i++) {
+      const item = Object.keys(this.HUD)[i];
+      const elements = this.HUD[item];
+      for (let j = 0; j < elements.length; j++) {
+        const element = elements[j];
+        const iconHTML = this.inventory.getItemIcon(item);
+        for (let k = 0; k < element.classList.length; k++) {
+          const className = element.classList[k];
+          if (className.includes("-icon")) {
+            if (iconHTML) {
+              element.innerHTML = iconHTML;
+            } else {
+              element.innerHTML = "";
+            }
+          }
+        }
+      }
+    }
+  }
+
+  syncCounts() {
+    for (let i = 0; i < Object.keys(this.HUD).length; i++) {
+      const item = Object.keys(this.HUD)[i];
+      const elements = this.HUD[item];
+      for (let j = 0; j < elements.length; j++) {
+        const element = elements[j];
+        const itemObj = this.inventory.getItemByName(item);
+        for (let k = 0; k < element.classList.length; k++) {
+          const className = element.classList[k];
+          if (className.includes("-count")) {
+            if (itemObj) {
+              element.innerHTML = itemObj.count;
+            } else {
+              element.innerHTML = "";
+            }
+          }
+        }
+      }
+    }
+  }
+
+  updateCountForItem(name) {
+    const item = this.inventory.getItemByName(name);
+    if (item) {
+      for (let i = 0; i < Object.keys(this.HUD).length; i++) {
+        const itemName = Object.keys(this.HUD)[i];
+        if (itemName === name) {
+          const elements = this.HUD[itemName];
+          for (let j = 0; j < elements.length; j++) {
+            const element = elements[j];
+            for (let k = 0; k < element.classList.length; k++) {
+              const className = element.classList[k];
+              if (className.includes("-count")) {
+                element.innerHTML = item.count;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  syncInventoryMenu() {
+    const inventoryMenu = document.getElementById("inventory-menu");
+    const itemList = inventoryMenu.querySelector(".item-list");
+    const itemListPatternElement = inventoryMenu.querySelector(".list-pattern");
+    const itemListPattern =
+      itemListPatternElement.querySelector(".item-wrapper");
+
+    const itemListPatternTemplate = itemListPattern.cloneNode(true);
+    itemList.innerHTML = "";
+    itemList.appendChild(itemListPatternElement);
+    if (!gameInstance.debug) {
+      itemListPatternElement.style.display = "none";
+    }
+
+    for (let i = 0; i < this.inventory.itemsList.length; i++) {
+      const item = this.inventory.itemsList[i];
+      const itemElement = itemListPatternTemplate.cloneNode(true);
+      const itemIcon = itemElement.querySelector(".item-icon");
+      const itemName = itemElement.querySelector(".item-name");
+      const itemCount = itemElement.querySelector(".item-count");
+      const itemDescription = itemElement.querySelector(".item-description");
+
+      const template = document.getElementById(item.templateId);
+      let inspectHTML = "";
+      let iconHTML = "";
+      if (template) {
+        const fragment = template.content.cloneNode(true);
+        const tplItem = fragment.querySelector('.item');
+        iconHTML = tplItem.querySelector('.iconElement')?.outerHTML || "";
+        inspectHTML = tplItem.querySelector('.inspectElement')?.outerHTML || "";
+      }
+
+      if (itemIcon && iconHTML) {
+        itemIcon.innerHTML = iconHTML;
+        if (itemIcon.title == "item-description") {
+          itemIcon.title = item.description || "No description available";
+        } else if (itemIcon.title == "item-name") {
+          itemIcon.title = item.name || "No name available";
+        } else if (itemIcon.title == "item-count") {
+          itemIcon.title = item.count || "No count available";
+        }
+      }
+      if (itemName) {
+        itemName.innerHTML = item.name;
+        if (itemName.title == "item-description") {
+          itemName.title = item.description || "No description available";
+        } else if (itemName.title == "item-name") {
+          itemName.title = item.name || "No name available";
+        } else if (itemName.title == "item-count") {
+          itemName.title = item.count || "No count available";
+        }
+      }
+      if (itemCount) {
+        itemCount.innerHTML = item.count;
+        if (itemCount.title == "item-description") {
+          itemCount.title = item.description || "No description available";
+        } else if (itemCount.title == "item-name") {
+          itemCount.title = item.name || "No name available";
+        } else if (itemCount.title == "item-count") {
+          itemCount.title = item.count || "No count available";
+        }
+      }
+      if (itemDescription) {
+        itemDescription.innerHTML =
+          item.description || "No description available";
+        if (itemDescription.title == "item-description") {
+          itemDescription.title =
+            item.description || "No description available";
+        } else if (itemDescription.title == "item-name") {
+          itemDescription.title = item.name || "No name available";
+        } else if (itemDescription.title == "item-count") {
+          itemDescription.title = item.count || "No count available";
+        }
+      }
+
+      const useButton = itemElement.querySelector(".use-button");
+      if (useButton) {
+        useButton.onclick = () => {
+          if (item.onclick) {
+            const body = item.onclick
+              .substring(
+                item.onclick.indexOf("{") + 1,
+                item.onclick.lastIndexOf("}")
+              )
+              .trim();
+            const func = new Function(body);
+            func.call(item); // 'item' as 'this'
+          }
+        };
+      } else {
+        itemElement.onclick = () => {
+          if (item.onclick) {
+            const body = item.onclick
+              .substring(
+                item.onclick.indexOf("{") + 1,
+                item.onclick.lastIndexOf("}")
+              )
+              .trim();
+            const func = new Function(body);
+            func.call(item);
+          }
+        };
+      }
+
+      const inspectButton = itemElement.querySelector(".inspect-button");
+      if (inspectButton) {
+        inspectButton.onclick = () => {
+          console.log("Inspecting item:", item.name);
+          const inspectWindow = document.createElement("div");
+          inspectWindow.className = "inspect-window";
+          inspectWindow.innerHTML = inspectHTML;
+          inspectWindow.title = "click to close";
+          document.body.appendChild(inspectWindow);
+
+          const removeFromDocument = (event) => {
+            if (event.key === "Escape") {
+              document.body.removeChild(inspectWindow);
+              document.removeEventListener("keydown", removeFromDocument);
+            }
+          };
+
+          inspectWindow.onclick = (event) => {
+            if (event.target === inspectWindow) {
+              document.body.removeChild(inspectWindow);
+              document.removeEventListener("keydown", removeFromDocument);
+            }
+          };
+          document.addEventListener("keydown", removeFromDocument);
+        };
+      }
+
+      itemList.appendChild(itemElement);
+    }
+  }
+}
+

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1,11 +1,21 @@
-import gameInstance from "./game.js";
-
 export default class Inventory {
   constructor() {
     this.pickupIDs = [];
     this.itemsList = [];
     this.syncToInventory();
-    this.HUD = new HUD(this);
+    this.eventTarget = new EventTarget();
+  }
+
+  on(eventName, listener) {
+    this.eventTarget.addEventListener(eventName, listener);
+  }
+
+  off(eventName, listener) {
+    this.eventTarget.removeEventListener(eventName, listener);
+  }
+
+  emit(eventName, detail) {
+    this.eventTarget.dispatchEvent(new CustomEvent(eventName, { detail }));
   }
 
   // Sync itemsList with localstorage
@@ -31,8 +41,6 @@ export default class Inventory {
 
   // Add item to the inventory
   addItem(item) {
-    item.inspectElement = item.inspectElement.outerHTML;
-    item.iconElement = item.iconElement.outerHTML;
     // Check if item is already in the inventory
     const existingItem = this.itemsList.find((i) => i.name === item.name);
     if (existingItem) {
@@ -40,16 +48,13 @@ export default class Inventory {
       existingItem.pickupIDs.push(item.pickupID);
       // Remove duplicate pickupIDs
       existingItem.pickupIDs = [...new Set(existingItem.pickupIDs)];
-      // Update the HUD count for the item
-      this.HUD.updateCountForItem(item.name);
+      this.emit('itemAdded', { item: existingItem });
     } else {
       const pickupID = item.pickupID;
       delete item.pickupID;
       item.pickupIDs = [pickupID];
       this.itemsList.push(item);
-      // Update the HUD count for the item
-      this.HUD.updateCountForItem(item.name);
-      this.HUD.setIcons();
+      this.emit('itemAdded', { item });
     }
     console.log(this.itemsList);
     // Sync localstorage with itemsList
@@ -66,6 +71,7 @@ export default class Inventory {
       }
       // Sync localstorage with itemsList
       this.syncToLocalStorage();
+      this.emit('itemRemoved', { item });
     }
   }
   // Remove item from the inventory by pickupID
@@ -79,6 +85,7 @@ export default class Inventory {
       }
       // Sync localstorage with itemsList
       this.syncToLocalStorage();
+      this.emit('itemRemoved', { item });
     }
   }
 
@@ -109,7 +116,11 @@ export default class Inventory {
   getItemIcon(name) {
     const item = this.itemsList.find((i) => i.name === name);
     if (item) {
-      return item.iconElement;
+      const template = document.getElementById(item.templateId);
+      if (template) {
+        const icon = template.content.querySelector('.iconElement');
+        return icon ? icon.outerHTML : null;
+      }
     }
     return null;
   }
@@ -123,11 +134,11 @@ export default class Inventory {
       item.name = newItem.name;
       item.description = newItem.description;
       item.count = newItem.count;
-      item.inspectElement = newItem.inspectElement.outerHTML;
-      item.iconElement = newItem.iconElement.outerHTML;
+      item.templateId = newItem.templateId;
       item.onclick = newItem.onclick;
       // Sync localstorage with itemsList
       this.syncToLocalStorage();
+      this.emit('itemModified', { item });
     }
   }
 }
@@ -138,8 +149,7 @@ export class InventoryItem {
     pickupID,
     description,
     count,
-    iconElement,
-    inspectElement,
+    templateId,
     onclick,
     tags = []
   ) {
@@ -153,10 +163,8 @@ export class InventoryItem {
     this.description = description;
     // The count of the item in the inventory
     this.count = count;
-    // The element that will be used to display the item in the inventory
-    this.iconElement = iconElement;
-    // The element that will be used if you want to inspect the item in the inventory
-    this.inspectElement = inspectElement;
+    // Reference to the template defining the item's markup
+    this.templateId = templateId;
     // The code to be executed when the item is triggered
     this.onclick = onclick;
     // tags will be used to modify behavior of the item
@@ -172,257 +180,5 @@ export class InventoryItem {
       .trim();
     const func = new Function(body);
     func.call(this);
-  }
-}
-
-export class HUD {
-  constructor(player_inventory) {
-    this.inventory = player_inventory;
-    this.HUD = {};
-    this.initialize();
-  }
-
-  initialize() {
-    this.mapHudElements();
-    this.syncCounts();
-    this.setIcons();
-  }
-
-  mapHudElements() {
-    let elements = document.querySelectorAll(".hud-item");
-    let itemsList = [];
-    let hudElements = {};
-    for (let i = 0; i < elements.length; i++) {
-      const element = elements[i];
-      for (let j = 0; j < element.classList.length; j++) {
-        const className = element.classList[j];
-        if (className.startsWith("hud-") && className !== "hud-item") {
-          const tag = className.split("-")[1];
-          itemsList.push(tag);
-        }
-        if (className.startsWith("hud-") && className !== "hud-item") {
-          const tag = className.replace("hud-", "");
-          hudElements[tag] = element;
-        }
-      }
-    }
-    for (let i = 0; i < itemsList.length; i++) {
-      const item = itemsList[i];
-      for (let j = 0; j < Object.keys(hudElements).length; j++) {
-        const element = hudElements[Object.keys(hudElements)[j]];
-        for (let k = 0; k < element.classList.length; k++) {
-          const className = element.classList[k];
-          if (className.includes(item)) {
-            if (this.HUD[item] === undefined) {
-              this.HUD[item] = [element];
-            } else {
-              this.HUD[item].push(element);
-            }
-          }
-        }
-      }
-      // clear duplicates from this.HUD[item]
-      if (this.HUD[item] !== undefined) {
-        this.HUD[item] = [...new Set(this.HUD[item])];
-      }
-    }
-  }
-
-  setIcons() {
-    for (let i = 0; i < Object.keys(this.HUD).length; i++) {
-      const item = Object.keys(this.HUD)[i];
-      const elements = this.HUD[item];
-      for (let j = 0; j < elements.length; j++) {
-        const element = elements[j];
-        const itemObj = this.inventory.getItemByName(item);
-        for (let k = 0; k < element.classList.length; k++) {
-          const className = element.classList[k];
-          if (className.includes("-icon")) {
-            if (itemObj) {
-              element.innerHTML = itemObj.iconElement;
-            } else {
-              element.innerHTML = "";
-            }
-          }
-        }
-      }
-    }
-  }
-
-  syncCounts() {
-    for (let i = 0; i < Object.keys(this.HUD).length; i++) {
-      const item = Object.keys(this.HUD)[i];
-      const elements = this.HUD[item];
-      for (let j = 0; j < elements.length; j++) {
-        const element = elements[j];
-        const itemObj = this.inventory.getItemByName(item);
-        for (let k = 0; k < element.classList.length; k++) {
-          const className = element.classList[k];
-          if (className.includes("-count")) {
-            if (itemObj) {
-              element.innerHTML = itemObj.count;
-            } else {
-              element.innerHTML = "";
-            }
-          }
-        }
-      }
-    }
-  }
-
-  updateCountForItem(name) {
-    const item = this.inventory.getItemByName(name);
-    if (item) {
-      for (let i = 0; i < Object.keys(this.HUD).length; i++) {
-        const itemName = Object.keys(this.HUD)[i];
-        if (itemName === name) {
-          const elements = this.HUD[itemName];
-          for (let j = 0; j < elements.length; j++) {
-            const element = elements[j];
-            for (let k = 0; k < element.classList.length; k++) {
-              const className = element.classList[k];
-              if (className.includes("-count")) {
-                element.innerHTML = item.count;
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-
-  // Sync the inventory menu with the itemsList
-  syncInventoryMenu() {
-    const inventoryMenu = document.getElementById("inventory-menu");
-    const itemList = inventoryMenu.querySelector(".item-list");
-    const itemListPatternElement = inventoryMenu.querySelector(".list-pattern");
-    const itemListPattern =
-      itemListPatternElement.querySelector(".item-wrapper");
-
-    // Create a copy of the itemListPattern to use as a template
-    const itemListPatternTemplate = itemListPattern.cloneNode(true);
-    // Clear the itemList
-    itemList.innerHTML = "";
-    itemList.appendChild(itemListPatternElement);
-    if (!gameInstance.debug) {
-      itemListPatternElement.style.display = "none";
-    }
-
-    for (let i = 0; i < this.inventory.itemsList.length; i++) {
-      const item = this.inventory.itemsList[i];
-      const itemElement = itemListPatternTemplate.cloneNode(true);
-      const itemIcon = itemElement.querySelector(".item-icon");
-      const itemName = itemElement.querySelector(".item-name");
-      const itemCount = itemElement.querySelector(".item-count");
-      const itemDescription = itemElement.querySelector(".item-description");
-
-      // Replace the itemElement onClick with a method that displays the element's "inspectElement" in a window on screen
-
-      // Set the item icon, name, count, and description if not undefined
-      if (itemIcon && item.iconElement) {
-        itemIcon.innerHTML = item.iconElement;
-        if (itemIcon.title == "item-description") {
-          itemIcon.title = item.description || "No description available";
-        } else if (itemIcon.title == "item-name") {
-          itemIcon.title = item.name || "No name available";
-        } else if (itemIcon.title == "item-count") {
-          itemIcon.title = item.count || "No count available";
-        }
-      }
-      if (itemName) {
-        itemName.innerHTML = item.name;
-        if (itemName.title == "item-description") {
-          itemName.title = item.description || "No description available";
-        } else if (itemName.title == "item-name") {
-          itemName.title = item.name || "No name available";
-        } else if (itemName.title == "item-count") {
-          itemName.title = item.count || "No count available";
-        }
-      }
-      if (itemCount) {
-        itemCount.innerHTML = item.count;
-        if (itemCount.title == "item-description") {
-          itemCount.title = item.description || "No description available";
-        } else if (itemCount.title == "item-name") {
-          itemCount.title = item.name || "No name available";
-        } else if (itemCount.title == "item-count") {
-          itemCount.title = item.count || "No count available";
-        }
-      }
-      if (itemDescription) {
-        itemDescription.innerHTML =
-          item.description || "No description available";
-        if (itemDescription.title == "item-description") {
-          itemDescription.title =
-            item.description || "No description available";
-        } else if (itemDescription.title == "item-name") {
-          itemDescription.title = item.name || "No name available";
-        } else if (itemDescription.title == "item-count") {
-          itemDescription.title = item.count || "No count available";
-        }
-      }
-
-      const useButton = itemElement.querySelector(".use-button");
-      if (useButton) {
-        useButton.onclick = () => {
-          if (item.onclick) {
-            // Extract the function body from the string
-            const body = item.onclick
-              .substring(
-                item.onclick.indexOf("{") + 1,
-                item.onclick.lastIndexOf("}")
-              )
-              .trim();
-            const func = new Function(body);
-            func.call(item); // 'item' as 'this'
-          }
-        };
-      } else {
-        itemElement.onclick = () => {
-          if (item.onclick) {
-            const body = item.onclick
-              .substring(
-                item.onclick.indexOf("{") + 1,
-                item.onclick.lastIndexOf("}")
-              )
-              .trim();
-            const func = new Function(body);
-            func.call(item);
-          }
-        };
-      }
-
-      const inspectButton = itemElement.querySelector(".inspect-button");
-      if (inspectButton) {
-        inspectButton.onclick = () => {
-          console.log("Inspecting item:", item.name);
-          // Create a new window to display the inspectElement
-          const inspectWindow = document.createElement("div");
-          inspectWindow.className = "inspect-window";
-          inspectWindow.innerHTML = item.inspectElement;
-          inspectWindow.title = "click to close";
-          document.body.appendChild(inspectWindow);
-
-          const removeFromDocument = (event) => {
-            if (event.key === "Escape") {
-              document.body.removeChild(inspectWindow);
-              document.removeEventListener("keydown", removeFromDocument);
-            }
-          };
-
-          // Close the inspect window when clicked
-          inspectWindow.onclick = (event) => {
-            if (event.target === inspectWindow) {
-              document.body.removeChild(inspectWindow);
-              document.removeEventListener("keydown", removeFromDocument);
-            }
-          };
-          // Close the inspect window when Escape is pressed
-          document.addEventListener("keydown", removeFromDocument);
-        };
-      }
-
-      itemList.appendChild(itemElement);
-    }
   }
 }

--- a/js/itemTemplates.js
+++ b/js/itemTemplates.js
@@ -1,0 +1,17 @@
+export async function loadItemTemplates() {
+  const url = new URL('../items.html', import.meta.url);
+  const response = await fetch(url);
+  const text = await response.text();
+  const doc = new DOMParser().parseFromString(text, 'text/html');
+  doc.querySelectorAll('template').forEach((tpl) => {
+    document.body.appendChild(tpl);
+  });
+}
+
+export function renderItemDemos(container = document.body) {
+  const templates = document.querySelectorAll('template');
+  templates.forEach((tpl) => {
+    const fragment = tpl.content.cloneNode(true);
+    container.appendChild(fragment);
+  });
+}

--- a/js/levelObjects.js
+++ b/js/levelObjects.js
@@ -334,7 +334,13 @@ export const ItemPickupMixin = Base => class extends Base {
     pickup() {
         this.enabled = false;
         this.element.click();
-        const itemElement = this.element.querySelector('.item')
+
+        const templateId = this.element.dataset.template;
+        const template = document.getElementById(templateId);
+        if (!template) return;
+        const fragment = template.content.cloneNode(true);
+        const itemElement = fragment.querySelector('.item');
+
         let itemName = "";
         // extract item name from name-ITEMNAME class
         for (let i = 0; i < itemElement.classList.length; i++) {
@@ -342,7 +348,8 @@ export const ItemPickupMixin = Base => class extends Base {
                 itemName = itemElement.classList[i].replace('name-', '');
             }
         }
-        const onClick = itemElement.onclick
+
+        const onClick = itemElement.onclick;
         // convert onClick to a string
         let onClickString;
         if (onClick) {
@@ -351,17 +358,16 @@ export const ItemPickupMixin = Base => class extends Base {
             onClickString = onClickString.replace('function', '');
             onClickString = onClickString.replace(/\(.*?\)/, '');
         }
-        const inspectElement = itemElement.querySelector('.inspectElement')
-        const iconElement = itemElement.querySelector('.iconElement')
-        const description = itemElement.querySelector('.description').innerHTML
-        const count = parseInt(itemElement.querySelector('.count').innerHTML)
-        const item = new InventoryItem(itemName, this.element.id, description, count, iconElement, inspectElement, onClickString);
+
+        const description = itemElement.querySelector('.description').innerHTML;
+        const count = parseInt(itemElement.querySelector('.count').innerHTML);
+        const item = new InventoryItem(itemName, this.element.id, description, count, templateId, onClickString);
         this.element.remove();
         if (this.element.classList.contains('instant-use')) {
             item.triggerOnClick();
             return;
         }
-        player.inventory.addItem(item)
+        player.inventory.addItem(item);
     }
 };
 ItemPickupMixin.tags = ['collision', 'trigger', 'interactable'];

--- a/js/platformer.js
+++ b/js/platformer.js
@@ -2,11 +2,13 @@ import gameInstance from "./game.js";
 import Player from "./player.js";
 import Level from "./level.js";
 import { hasSubstringInClassList } from "./tools.js";
+import { loadItemTemplates } from "./itemTemplates.js";
 // Animation Implementation Discussion
 // https://chatgpt.com/c/d6c3427f-edfa-4d17-bb39-a9a15b01fda5
 // Usage
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
+    await loadItemTemplates();
     const playerElement = document.getElementById('player');
     gameInstance.setPlayer(new Player(playerElement));
     gameInstance.setLevel(new Level("level-one"));

--- a/js/player.js
+++ b/js/player.js
@@ -4,7 +4,8 @@ import GifAnimationManager from "./gifAnimationManager.js";
 import { Physics } from "./physics.js";
 import { CollisionDetection } from "./collisionDetector.js";
 import InteractionBox from "./interactionBox.js";
-import Inventory, { InventoryItem } from "./inventory.js";
+import Inventory from "./inventory.js";
+import HUD from "./hud.js";
 
 export default class Player {
     constructor(element) {
@@ -61,6 +62,7 @@ export default class Player {
         this.interactionBox = new InteractionBox(this);
         // Inventory
         this.inventory = new Inventory();
+        this.HUD = new HUD(this.inventory);
         // This lets the HTML as well as the console access the player object
         window.player = this;
     }


### PR DESCRIPTION
## Summary
- Define items with HTML `<template>` elements and reference them from pickups
- Store template IDs in the inventory and emit events for item changes
- Move HUD logic to a standalone module that rebuilds item UI from templates
- Centralize item templates in a shared `items.html` file loaded on every page, which also serves as an item demo

## Testing
- `npm test` *(fails: package.json not found)*
- `node --check js/inventory.js js/hud.js js/levelObjects.js js/player.js js/game.js js/platformer.js js/itemTemplates.js`

------
https://chatgpt.com/codex/tasks/task_b_68a763bdcabc832e9d0931767cbfe969