### PR TITLE
Add one-way solid level objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,19 @@ Defines in‑level object types:
 - `InteractableObject` and `InteractableToggle`: elements that react to player interaction and can broadcast signals.
 - `Reciever`: shows different child elements based on received signals.
 - `Slope`: ramp geometry. Combine classes `object`, `solid` and `slope` and set `data-slope` to `up-right`, `up-left`, `down-right` or `down-left`.
+- `OneWaySolid`: blocks movement from one side. Use classes `object solid oneway-DIR` where `DIR` is `up`, `down`, `left` or `right`.
 
 Example sloped surface:
 
 ```html
 <div class="object solid slope" data-slope="up-right"
      style="width:200px;height:200px;clip-path:polygon(0% 100%,100% 100%,100% 0%);"></div>
+```
+
+Example one-way platform:
+
+```html
+<div class="object solid oneway-up" style="width:100px;height:20px;"></div>
 ```
 
 Example toggle/receiver pair:

--- a/html/platformer.html
+++ b/html/platformer.html
@@ -56,6 +56,7 @@
                         <img class="wait" src="../img/cat_fall_asleep.gif" alt="A cat falling asleep">
                     </div>
                 </div>
+                <div class="solid object oneway-up" style="width: 300px; height: 30px; background-color: blue; left: 150px; bottom: 25%;"></div>
                 <!-- <div class="nekkoGAMETOY">
                     <div class="nGT-title">Game Name</div>
                     <div class="nGT-screen">

--- a/js/collisionDetector.js
+++ b/js/collisionDetector.js
@@ -61,22 +61,48 @@ export class CollisionDetection {
         let collisionCount = 0;
         collisionObjects.forEach(collisionObject => {
             if (!collisionObject.enabled) return;
-            if (collisionObject.element.classList.contains('trigger')) return;
-            if (collisionObject.element.classList.contains('slope')) return;
-            const collisionRect = collisionObject.element.getBoundingClientRect();
+            const el = collisionObject.element;
+            if (el.classList.contains('trigger')) return;
+            if (el.classList.contains('slope')) return;
+            const collisionRect = el.getBoundingClientRect();
             if (intersects(playerRect, collisionRect)) {
                 const collision = getCollisionOverlap(playerRect, collisionRect);
-                if (collision.bottom > 0 && collisionObject.element.classList.contains('solid')) {
-                    collisionCount++;
-                    this.state.bottom = collision.bottom;
-                    object.y -= collision.bottom;
-                    object.velocityY = 0;
+                const dirClass = Array.from(el.classList).find(cls => cls.startsWith('oneway-'));
+                const dir = dirClass ? dirClass.split('-')[1] : null;
+                const isOneWay = dir !== null;
+                if (collision.bottom > 0) {
+                    if (isOneWay && dir === 'up') {
+                        if (object.velocityY >= 0) {
+                            collisionCount++;
+                            this.state.bottom = collision.bottom;
+                            object.y -= collision.bottom;
+                            object.velocityY = 0;
+                        }
+                    } else if (!isOneWay || dir !== 'down') {
+                        if (el.classList.contains('solid')) {
+                            collisionCount++;
+                            this.state.bottom = collision.bottom;
+                            object.y -= collision.bottom;
+                            object.velocityY = 0;
+                        }
+                    }
                 }
-                if (collision.top > 0 && collisionObject.element.classList.contains('solid')) {
-                    collisionCount++;
-                    this.state.top = collision.top;
-                    object.y += collision.top;
-                    object.velocityY = 0;
+                if (collision.top > 0) {
+                    if (isOneWay && dir === 'down') {
+                        if (object.velocityY <= 0) {
+                            collisionCount++;
+                            this.state.top = collision.top;
+                            object.y += collision.top;
+                            object.velocityY = 0;
+                        }
+                    } else if (!isOneWay || dir !== 'up') {
+                        if (el.classList.contains('solid')) {
+                            collisionCount++;
+                            this.state.top = collision.top;
+                            object.y += collision.top;
+                            object.velocityY = 0;
+                        }
+                    }
                 }
             }
         });
@@ -88,22 +114,48 @@ export class CollisionDetection {
         let collisionCount = 0;
         collisionObjects.forEach(collisionObject => {
             if (!collisionObject.enabled) return;
-            if (collisionObject.element.classList.contains('trigger')) return;
-            if (collisionObject.element.classList.contains('slope')) return;
-            const collisionRect = collisionObject.element.getBoundingClientRect();
+            const el = collisionObject.element;
+            if (el.classList.contains('trigger')) return;
+            if (el.classList.contains('slope')) return;
+            const collisionRect = el.getBoundingClientRect();
             if (intersects(playerRect, collisionRect)) {
                 const collision = getCollisionOverlap(playerRect, collisionRect);
-                if (collision.left > 0 && collisionObject.element.classList.contains('solid')) {
-                    this.state.left = collision.left;
-                    object.x += collision.left;
-                    object.velocityX = 0;
-                    collisionCount++;
+                const dirClass = Array.from(el.classList).find(cls => cls.startsWith('oneway-'));
+                const dir = dirClass ? dirClass.split('-')[1] : null;
+                const isOneWay = dir !== null;
+                if (collision.left > 0) {
+                    if (isOneWay && dir === 'right') {
+                        if (object.velocityX <= 0) {
+                            this.state.left = collision.left;
+                            object.x += collision.left;
+                            object.velocityX = 0;
+                            collisionCount++;
+                        }
+                    } else if (!isOneWay || dir !== 'left') {
+                        if (el.classList.contains('solid')) {
+                            this.state.left = collision.left;
+                            object.x += collision.left;
+                            object.velocityX = 0;
+                            collisionCount++;
+                        }
+                    }
                 }
-                if (collision.right > 0 && collisionObject.element.classList.contains('solid')) {
-                    collisionCount++;
-                    this.state.right = collision.right;
-                    object.x -= collision.right;
-                    object.velocityX = 0;
+                if (collision.right > 0) {
+                    if (isOneWay && dir === 'left') {
+                        if (object.velocityX >= 0) {
+                            collisionCount++;
+                            this.state.right = collision.right;
+                            object.x -= collision.right;
+                            object.velocityX = 0;
+                        }
+                    } else if (!isOneWay || dir !== 'right') {
+                        if (el.classList.contains('solid')) {
+                            collisionCount++;
+                            this.state.right = collision.right;
+                            object.x -= collision.right;
+                            object.velocityX = 0;
+                        }
+                    }
                 }
             }
         });

--- a/js/levelObjects.js
+++ b/js/levelObjects.js
@@ -65,6 +65,14 @@ export class SolidObject extends LevelObject{
     }
 }
 
+export class OneWaySolidObject extends SolidObject {
+    constructor(element) {
+        super(element);
+        const dirClass = Array.from(element.classList).find(cls => cls.startsWith('oneway-'));
+        this.direction = dirClass ? dirClass.split('-')[1] : 'up';
+    }
+}
+
 export class TriggerArea extends LevelObject {
     constructor(element) {
         super(element);

--- a/js/objectFactory.js
+++ b/js/objectFactory.js
@@ -1,4 +1,4 @@
-import { SolidObject, InteractableObject, InteractableToggle, Reciever, LevelObject, TriggerArea } from "./levelObjects.js";
+import { SolidObject, InteractableObject, InteractableToggle, Reciever, LevelObject, TriggerArea, OneWaySolidObject } from "./levelObjects.js";
 
 const objectFactory = {
     solid: SolidObject,
@@ -11,6 +11,10 @@ const objectFactory = {
 
 export function createObject(element) {
     const classes = Array.from(element.classList);
+    const oneWayClass = classes.find(cls => cls.startsWith('oneway-'));
+    if (oneWayClass && classes.includes('solid')) {
+        return { type: 'solid', instance: new OneWaySolidObject(element) };
+    }
     let type = classes.find(cls => objectFactory[cls]);
 
     if (type === 'interactable' && classes.includes('toggle')) {


### PR DESCRIPTION
## Summary
- add `OneWaySolidObject` class supporting one-directional collision
- update object factory and collision detection to handle `oneway-*` direction classes
- document usage of one-way platforms in README

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/collisionDetector.js`
- `node --check js/levelObjects.js`
- `node --check js/objectFactory.js`


------
https://chatgpt.com/codex/tasks/task_b_68aa49bb6534832e848a23c68a02c0c6