### PR TITLE
Fix corner collision handling to prevent slipping

### DIFF
--- a/js/collisionDetector.js
+++ b/js/collisionDetector.js
@@ -119,10 +119,20 @@ export class CollisionDetection {
             if (el.classList.contains('slope')) return;
             const collisionRect = el.getBoundingClientRect();
             if (intersects(playerRect, collisionRect)) {
-                const collision = getCollisionOverlap(playerRect, collisionRect);
                 const dirClass = Array.from(el.classList).find(cls => cls.startsWith('oneway-'));
                 const dir = dirClass ? dirClass.split('-')[1] : null;
                 const isOneWay = dir !== null;
+
+                // Skip horizontal resolution when approaching the pass-through side
+                if (isOneWay && (dir === 'up' || dir === 'down')) {
+                    const approachingFromBelow = dir === 'up' && playerRect.top >= collisionRect.top;
+                    const approachingFromAbove = dir === 'down' && playerRect.bottom <= collisionRect.bottom;
+                    if (approachingFromBelow || approachingFromAbove) {
+                        return;
+                    }
+                }
+
+                const collision = getCollisionOverlap(playerRect, collisionRect);
                 if (collision.left > 0) {
                     if (isOneWay && dir === 'right') {
                         if (object.velocityX <= 0) {

--- a/js/collisionDetector.js
+++ b/js/collisionDetector.js
@@ -13,23 +13,10 @@ export class CollisionDetection {
 
     applyCollisions(object, collisionObjects) {
         this.checkOutOfBounds(object);
-        // Ensure DOM position reflects any out-of-bounds adjustments
-        object.element.style.left = `${object.x}px`;
-        object.element.style.top = `${object.y}px`;
         this.checkTriggerCollisions(object, collisionObjects);
-        // Resolve vertical movement before horizontal to avoid corner sliding
-        let vertical_collision_count = this.checkVerticalCollisions(object, collisionObjects);
-        // Update DOM position after vertical resolution
-        object.element.style.left = `${object.x}px`;
-        object.element.style.top = `${object.y}px`;
         let horizontal_collision_count = this.checkHorizontalCollisions(object, collisionObjects);
-        // Update again before slope checks so they use corrected position
-        object.element.style.left = `${object.x}px`;
-        object.element.style.top = `${object.y}px`;
+        let vertical_collision_count = this.checkVerticalCollisions(object, collisionObjects);
         let slope_collision_count = this.checkSlopeCollisions(object, collisionObjects);
-        // Final update to reflect any slope adjustments
-        object.element.style.left = `${object.x}px`;
-        object.element.style.top = `${object.y}px`;
         if (horizontal_collision_count <= 0) {
             this.state = {
                 left: 0,

--- a/js/collisionDetector.js
+++ b/js/collisionDetector.js
@@ -119,10 +119,20 @@ export class CollisionDetection {
             if (el.classList.contains('slope')) return;
             const collisionRect = el.getBoundingClientRect();
             if (intersects(playerRect, collisionRect)) {
-                const collision = getCollisionOverlap(playerRect, collisionRect);
                 const dirClass = Array.from(el.classList).find(cls => cls.startsWith('oneway-'));
                 const dir = dirClass ? dirClass.split('-')[1] : null;
                 const isOneWay = dir !== null;
+
+                // Skip horizontal resolution when approaching the pass-through side
+                if (isOneWay && (dir === 'up' || dir === 'down')) {
+                    const approachingFromBelow = dir === 'up' && playerRect.bottom >= collisionRect.top;
+                    const approachingFromAbove = dir === 'down' && playerRect.top <= collisionRect.bottom;
+                    if (approachingFromBelow || approachingFromAbove) {
+                        return;
+                    }
+                }
+
+                const collision = getCollisionOverlap(playerRect, collisionRect);
                 if (collision.left > 0) {
                     if (isOneWay && dir === 'right') {
                         if (object.velocityX <= 0) {

--- a/js/collisionDetector.js
+++ b/js/collisionDetector.js
@@ -13,10 +13,23 @@ export class CollisionDetection {
 
     applyCollisions(object, collisionObjects) {
         this.checkOutOfBounds(object);
+        // Ensure DOM position reflects any out-of-bounds adjustments
+        object.element.style.left = `${object.x}px`;
+        object.element.style.top = `${object.y}px`;
         this.checkTriggerCollisions(object, collisionObjects);
-        let horizontal_collision_count = this.checkHorizontalCollisions(object, collisionObjects);
+        // Resolve vertical movement before horizontal to avoid corner sliding
         let vertical_collision_count = this.checkVerticalCollisions(object, collisionObjects);
+        // Update DOM position after vertical resolution
+        object.element.style.left = `${object.x}px`;
+        object.element.style.top = `${object.y}px`;
+        let horizontal_collision_count = this.checkHorizontalCollisions(object, collisionObjects);
+        // Update again before slope checks so they use corrected position
+        object.element.style.left = `${object.x}px`;
+        object.element.style.top = `${object.y}px`;
         let slope_collision_count = this.checkSlopeCollisions(object, collisionObjects);
+        // Final update to reflect any slope adjustments
+        object.element.style.left = `${object.x}px`;
+        object.element.style.top = `${object.y}px`;
         if (horizontal_collision_count <= 0) {
             this.state = {
                 left: 0,

--- a/js/tools.js
+++ b/js/tools.js
@@ -1,11 +1,10 @@
 import gameInstance from "./game.js";
 
 export const intersects = (rect1, rect2) => {
-    let isIntersecting = !(rect2.left > rect1.right ||
-        rect2.right < rect1.left ||
-        rect2.top > rect1.bottom ||
-        rect2.bottom < rect1.top);
-    return isIntersecting;
+    return !(rect2.left >= rect1.right ||
+        rect2.right <= rect1.left ||
+        rect2.top >= rect1.bottom ||
+        rect2.bottom <= rect1.top);
 }
 
 export const getCollisionOverlap = (rect1, rect2) => {
@@ -48,16 +47,16 @@ export const getCollisionOverlap = (rect1, rect2) => {
 
     if (rect1BottomSide > rect2TopSide
         && rect1TopSide < rect2TopSide
-        && rect1CenterX > rect2LeftSide
-        && rect1CenterX < rect2RightSide
+        && rect1RightSide > rect2LeftSide
+        && rect1LeftSide < rect2RightSide
     ) {
         collisionDirections.bottom = rect1BottomSide - rect2TopSide;
     }
 
     if (rect1TopSide < rect2BottomSide
         && rect1BottomSide > rect2BottomSide
-        && rect1CenterX > rect2LeftSide
-        && rect1CenterX < rect2RightSide
+        && rect1RightSide > rect2LeftSide
+        && rect1LeftSide < rect2RightSide
     ) {
         collisionDirections.top = rect2BottomSide - rect1TopSide;
     }


### PR DESCRIPTION
## Summary
- Resolve vertical movement before horizontal to avoid corner sliding
- Update DOM element position after each collision pass to keep bounding boxes accurate

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_68ab5ff803f0832e9ba0bf6bd97690d6