### PR TITLE
refactor: use transforms for player movement

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -2,8 +2,8 @@
     --screen-width: 100vw;
     --screen-height: 100vh;
     --debug: hidden;
-    --player-spawn-x: 50px;
-    --player-spawn-y: calc(100% - 100px);
+    --player-spawn-x: 50vw;
+    --player-spawn-y: calc(100vh - 100px);
 }
 
 .debug {

--- a/js/camera.js
+++ b/js/camera.js
@@ -37,8 +37,7 @@ export default class Camera {
     }
 
     positionOverlay() {
-        this.overlayElement.style.left = this.element.scrollLeft + 'px';
-        this.overlayElement.style.top = this.element.scrollTop + 'px';
+        this.overlayElement.style.transform = `translate(${this.element.scrollLeft}px, ${this.element.scrollTop}px)`;
     }
 
     initStyles() {

--- a/js/collisionDetector.js
+++ b/js/collisionDetector.js
@@ -13,6 +13,7 @@ export class CollisionDetection {
 
     applyCollisions(object, collisionObjects) {
         this.checkOutOfBounds(object);
+        object.updateTransform?.();
         this.checkTriggerCollisions(object, collisionObjects);
         let horizontal_collision_count = this.checkHorizontalCollisions(object, collisionObjects);
         let vertical_collision_count = this.checkVerticalCollisions(object, collisionObjects);
@@ -57,13 +58,13 @@ export class CollisionDetection {
     }
 
     checkVerticalCollisions(object, collisionObjects) {
-        const playerRect = object.element.getBoundingClientRect();
         let collisionCount = 0;
         collisionObjects.forEach(collisionObject => {
             if (!collisionObject.enabled) return;
             const el = collisionObject.element;
             if (el.classList.contains('trigger')) return;
             if (el.classList.contains('slope')) return;
+            const playerRect = object.element.getBoundingClientRect();
             const collisionRect = el.getBoundingClientRect();
             if (intersects(playerRect, collisionRect)) {
                 const collision = getCollisionOverlap(playerRect, collisionRect);
@@ -77,6 +78,7 @@ export class CollisionDetection {
                             this.state.bottom = collision.bottom;
                             object.y -= collision.bottom;
                             object.velocityY = 0;
+                            object.updateTransform?.();
                         }
                     } else if (!isOneWay || dir !== 'down') {
                         if (el.classList.contains('solid')) {
@@ -84,6 +86,7 @@ export class CollisionDetection {
                             this.state.bottom = collision.bottom;
                             object.y -= collision.bottom;
                             object.velocityY = 0;
+                            object.updateTransform?.();
                         }
                     }
                 }
@@ -94,6 +97,7 @@ export class CollisionDetection {
                             this.state.top = collision.top;
                             object.y += collision.top;
                             object.velocityY = 0;
+                            object.updateTransform?.();
                         }
                     } else if (!isOneWay || dir !== 'up') {
                         if (el.classList.contains('solid')) {
@@ -101,6 +105,7 @@ export class CollisionDetection {
                             this.state.top = collision.top;
                             object.y += collision.top;
                             object.velocityY = 0;
+                            object.updateTransform?.();
                         }
                     }
                 }
@@ -110,13 +115,13 @@ export class CollisionDetection {
     }
 
     checkHorizontalCollisions(object, collisionObjects) {
-        const playerRect = object.element.getBoundingClientRect();
         let collisionCount = 0;
         collisionObjects.forEach(collisionObject => {
             if (!collisionObject.enabled) return;
             const el = collisionObject.element;
             if (el.classList.contains('trigger')) return;
             if (el.classList.contains('slope')) return;
+            const playerRect = object.element.getBoundingClientRect();
             const collisionRect = el.getBoundingClientRect();
             if (intersects(playerRect, collisionRect)) {
                 const dirClass = Array.from(el.classList).find(cls => cls.startsWith('oneway-'));
@@ -139,6 +144,7 @@ export class CollisionDetection {
                             this.state.left = collision.left;
                             object.x += collision.left;
                             object.velocityX = 0;
+                            object.updateTransform?.();
                             collisionCount++;
                         }
                     } else if (!isOneWay || dir !== 'left') {
@@ -146,6 +152,7 @@ export class CollisionDetection {
                             this.state.left = collision.left;
                             object.x += collision.left;
                             object.velocityX = 0;
+                            object.updateTransform?.();
                             collisionCount++;
                         }
                     }
@@ -153,17 +160,19 @@ export class CollisionDetection {
                 if (collision.right > 0) {
                     if (isOneWay && dir === 'left') {
                         if (object.velocityX >= 0) {
-                            collisionCount++;
                             this.state.right = collision.right;
                             object.x -= collision.right;
                             object.velocityX = 0;
+                            object.updateTransform?.();
+                            collisionCount++;
                         }
                     } else if (!isOneWay || dir !== 'right') {
                         if (el.classList.contains('solid')) {
-                            collisionCount++;
                             this.state.right = collision.right;
                             object.x -= collision.right;
                             object.velocityX = 0;
+                            object.updateTransform?.();
+                            collisionCount++;
                         }
                     }
                 }
@@ -173,11 +182,11 @@ export class CollisionDetection {
     }
 
     checkSlopeCollisions(object, collisionObjects) {
-        const playerRect = object.element.getBoundingClientRect();
         let collisionCount = 0;
         collisionObjects.forEach(collisionObject => {
             if (!collisionObject.enabled) return;
             if (!collisionObject.element.classList.contains('slope')) return;
+            const playerRect = object.element.getBoundingClientRect();
             const slopeRect = collisionObject.element.getBoundingClientRect();
             if (!intersects(playerRect, slopeRect)) return;
             const type = collisionObject.element.dataset.slope || 'up-right';
@@ -207,6 +216,7 @@ export class CollisionDetection {
                 object.y -= overlap;
                 object.velocityY = 0;
                 this.state.bottom = overlap;
+                object.updateTransform?.();
                 collisionCount++;
             }
         });
@@ -242,42 +252,50 @@ export class CollisionDetection {
             debugLog("Out of bounds left");
             if (outOfBoundEffect.left == "contain") {
                 object.x -= playerRect.left - levelRect.left;
+                object.updateTransform?.();
             } else if (outOfBoundEffect.left == "respawn") {
                 this.respawnAtCheckpoint();
             } else if (outOfBoundEffect.left == "wrap") {
                 object.x = levelRect.width - (playerRect.width * 1.25);
                 gameInstance.camera.snapToPlayer();
+                object.updateTransform?.();
             }
         } else if (playerRect.right > levelRect.right) {
             debugLog("Out of bounds right");
             if (outOfBoundEffect.right == "contain") {
                 object.x -= playerRect.right - levelRect.right;
+                object.updateTransform?.();
             } else if (outOfBoundEffect.right == "respawn") {
                 this.respawnAtCheckpoint();
             } else if (outOfBoundEffect.right == "wrap") {
                 object.x = 0 + (playerRect.width / 4)
                 gameInstance.camera.snapToPlayer();
+                object.updateTransform?.();
             }
         }
         if (playerRect.top < levelRect.top) {
             debugLog("Out of bounds top");
             if (outOfBoundEffect.top == "contain") {
                 object.y -= playerRect.top - levelRect.top;
+                object.updateTransform?.();
             } else if (outOfBoundEffect.top == "respawn") {
                 this.respawnAtCheckpoint();
             } else if (outOfBoundEffect.top == "wrap") {
                 object.y = levelRect.height - (playerRect.height + 1);
                 gameInstance.camera.snapToPlayer();
+                object.updateTransform?.();
             }
         } else if (playerRect.bottom > levelRect.bottom) {
             debugLog("Out of bounds bottom");
             if (outOfBoundEffect.bottom == "contain") {
                 object.y -= playerRect.height - (levelRect.bottom - playerRect.top);
+                object.updateTransform?.();
             } else if (outOfBoundEffect.bottom == "respawn") {
                 this.respawnAtCheckpoint();
             } else if (outOfBoundEffect.bottom == "wrap") {
                 object.y = 0;
                 gameInstance.camera.snapToPlayer();
+                object.updateTransform?.();
             }
 
         }

--- a/js/levelObjects.js
+++ b/js/levelObjects.js
@@ -94,8 +94,7 @@ export class MovingPlatform extends SolidObject {
         if (player.grounded && player.groundedObject === this) {
             player.x += deltaX;
             player.y += deltaY;
-            player.element.style.left = player.x + "px";
-            player.element.style.top = player.y + "px";
+            player.updateTransform();
         }
     }
 }

--- a/js/player.js
+++ b/js/player.js
@@ -59,6 +59,7 @@ export default class Player {
         this.currentAnimation = 'idle';
         //   Interaction
         this.interactionBox = new InteractionBox(this);
+        this.isFacingRight = false;
 
         // Cached DOM references
         this.xPositionDisplay = document.getElementById('xPositionDisplay');
@@ -126,12 +127,22 @@ export default class Player {
 
         const playerSpawnXRelativeToScreen = spawn_x_query_param == null ? getComputedStyle(document.documentElement).getPropertyValue('--player-spawn-x') : spawn_x_query_param;
         const playerSpawnYRelativeToScreen = spawn_y_query_param == null ? getComputedStyle(document.documentElement).getPropertyValue('--player-spawn-y') : spawn_y_query_param;
-        const screenXposition = this.respawnScreen.getBoundingClientRect().x;
-        const screenYposition = this.respawnScreen.getBoundingClientRect().y;
-        this.element.style.left = playerSpawnXRelativeToScreen;
-        this.element.style.top = playerSpawnYRelativeToScreen;
-        this.x = (this.element.getBoundingClientRect().x - screenXposition) - (this.element.getBoundingClientRect().width / 2);
-        this.y = (this.element.getBoundingClientRect().y - screenYposition) - (this.element.getBoundingClientRect().height / 2);
+        const screenRect = this.respawnScreen.getBoundingClientRect();
+        const width = this.element.getBoundingClientRect().width;
+        const height = this.element.getBoundingClientRect().height;
+
+        let xValue = parseFloat(playerSpawnXRelativeToScreen);
+        if (playerSpawnXRelativeToScreen.includes('%')) {
+            xValue = screenRect.width * (xValue / 100);
+        }
+        let yValue = parseFloat(playerSpawnYRelativeToScreen);
+        if (playerSpawnYRelativeToScreen.includes('%')) {
+            yValue = screenRect.height * (yValue / 100);
+        }
+
+        this.x = xValue - (width / 2);
+        this.y = yValue - (height / 2);
+        this.updateTransform();
     }
 
     spawnAt(playerSpawnXRelativeToScreen, playerSpawnYRelativeToScreen, screen) {
@@ -148,6 +159,7 @@ export default class Player {
         debugLog(screensToTheTop);
         this.x = (playerSpawnXRelativeToScreen) + (screensToTheLeft * screen.getBoundingClientRect().width) - (this.element.getBoundingClientRect().width / 2);
         this.y = (playerSpawnYRelativeToScreen) + (screensToTheTop * screen.getBoundingClientRect().height) - (this.element.getBoundingClientRect().height / 2);
+        this.updateTransform();
     }
 
     setCheckpointScreen(checkpoint_screen) {
@@ -175,18 +187,15 @@ export default class Player {
         for (let i = 0; i < iterations; i++) {
             this.x += this.velocityX / iterations;
             this.y += this.velocityY / iterations;
-            this.element.style.left = `${this.x}px`;
-            this.element.style.top = `${this.y}px`;
+            this.updateTransform();
             this.collision.applyCollisions(this, this.collisionObjects);
+            this.updateTransform();
             if (this.velocityX === 0 && this.velocityY === 0) break;
         }
 
         this.processCollisions();
         this.interactionBox.update();
         this.applyAnimations();
-        // Set the position of the player's HTML element
-        // this.element.style.left = `${this.x}px`;
-        // this.element.style.top = `${this.y}px`;
         if (this.xPositionDisplay) {
             this.xPositionDisplay.innerHTML = Math.round(this.x + this.element.getBoundingClientRect().width / 2);
         }
@@ -299,21 +308,28 @@ export default class Player {
     }
 
     lookRight() {
-        this.element.style.transform = 'rotateY(180deg)';
+        this.isFacingRight = true;
+        this.updateTransform();
         if (this.interactionBox.interactionIndicatorElement) {
             this.interactionBox.interactionIndicatorElement.style.transform = "translate(-50%, -100%) rotateY(180deg)";
         }
     }
 
     lookLeft() {
-        this.element.style.transform = 'rotateY(0deg)';
+        this.isFacingRight = false;
+        this.updateTransform();
         if (this.interactionBox.interactionIndicatorElement) {
             this.interactionBox.interactionIndicatorElement.style.transform = "translate(-50%, -100%) rotateY(0deg)";
         }
     }
 
     facingRight() {
-        return this.element.style.transform === 'rotateY(180deg)';
+        return this.isFacingRight;
+    }
+
+    updateTransform() {
+        const rotation = this.isFacingRight ? 'rotateY(180deg)' : 'rotateY(0deg)';
+        this.element.style.transform = `translate(${this.x}px, ${this.y}px) ${rotation}`;
     }
 
     setSolidObjects(solidObjects) {

--- a/js/player.js
+++ b/js/player.js
@@ -124,22 +124,56 @@ export default class Player {
     spawn() {
         const spawn_x_query_param = new URLSearchParams(window.location.search).get('spawn_x');
         const spawn_y_query_param = new URLSearchParams(window.location.search).get('spawn_y');
-
-        const playerSpawnXRelativeToScreen = spawn_x_query_param == null ? getComputedStyle(document.documentElement).getPropertyValue('--player-spawn-x') : spawn_x_query_param;
-        const playerSpawnYRelativeToScreen = spawn_y_query_param == null ? getComputedStyle(document.documentElement).getPropertyValue('--player-spawn-y') : spawn_y_query_param;
+        const playerSpawnXRelativeToScreen = spawn_x_query_param ? spawn_x_query_param : getComputedStyle(document.documentElement).getPropertyValue('--player-spawn-x');
+        const playerSpawnYRelativeToScreen = spawn_y_query_param ? spawn_y_query_param : getComputedStyle(document.documentElement).getPropertyValue('--player-spawn-y');
+        console.log(`Player spawn from CSS: (${playerSpawnXRelativeToScreen}, ${playerSpawnYRelativeToScreen})`);
         const screenRect = this.respawnScreen.getBoundingClientRect();
         const width = this.element.getBoundingClientRect().width;
         const height = this.element.getBoundingClientRect().height;
 
-        let xValue = parseFloat(playerSpawnXRelativeToScreen);
-        if (playerSpawnXRelativeToScreen.includes('%')) {
-            xValue = screenRect.width * (xValue / 100);
-        }
-        let yValue = parseFloat(playerSpawnYRelativeToScreen);
-        if (playerSpawnYRelativeToScreen.includes('%')) {
-            yValue = screenRect.height * (yValue / 100);
+        function evalCalc(expr, axis) {
+            // Replace percentages, px, vw, vh with pixel values
+            return expr
+                .replace(/([\d.]+)%/g, (m, p1) => {
+                    return axis === 'x' ? (screenRect.width * (parseFloat(p1) / 100)) : (screenRect.height * (parseFloat(p1) / 100));
+                })
+                .replace(/([\d.]+)vw/g, (m, p1) => window.innerWidth * (parseFloat(p1) / 100))
+                .replace(/([\d.]+)vh/g, (m, p1) => window.innerHeight * (parseFloat(p1) / 100))
+                .replace(/([\d.]+)px/g, (m, p1) => parseFloat(p1));
         }
 
+        function safeEval(expr) {
+            // Only allow numbers, +, -, *, /, (, ) and .
+            if (!/^[-+*/().\d\s]+$/.test(expr)) return NaN;
+            try {
+                return Function('return (' + expr + ')')();
+            } catch {
+                return NaN;
+            }
+        }
+
+        function parseValue(val, axis) {
+            val = val.trim();
+            if (val.startsWith('calc(')) {
+                let inner = val.slice(5, -1);
+                console.log(`Evaluating calc(${inner})`);
+                let replaced = evalCalc(inner, axis);
+                console.log(`Evaluating calc(${inner}) as ${replaced}`);
+                return safeEval(replaced);
+            } else if (val.includes('%')) {
+                let num = parseFloat(val);
+                return axis === 'x' ? (screenRect.width * (num / 100)) : (screenRect.height * (num / 100));
+            } else if (val.includes('px')) {
+                return parseFloat(val);
+            } else {
+                return parseFloat(val);
+            }
+        }
+
+        let xValue = parseValue(playerSpawnXRelativeToScreen, 'x');
+        let yValue = parseValue(playerSpawnYRelativeToScreen, 'y');
+
+        console.log(`Spawning player at (${xValue}, ${yValue}) relative to screen`);
         this.x = xValue - (width / 2);
         this.y = yValue - (height / 2);
         this.updateTransform();
@@ -188,6 +222,7 @@ export default class Player {
             this.x += this.velocityX / iterations;
             this.y += this.velocityY / iterations;
             this.updateTransform();
+            // console.log(this.element);
             this.collision.applyCollisions(this, this.collisionObjects);
             this.updateTransform();
             if (this.velocityX === 0 && this.velocityY === 0) break;
@@ -329,6 +364,7 @@ export default class Player {
 
     updateTransform() {
         const rotation = this.isFacingRight ? 'rotateY(180deg)' : 'rotateY(0deg)';
+        // console.log(`translate(${this.x}px, ${this.y}px) ${rotation}`)
         this.element.style.transform = `translate(${this.x}px, ${this.y}px) ${rotation}`;
     }
 


### PR DESCRIPTION
## Summary
- move player positioning to CSS transforms and central updateTransform helper
- adjust moving platform support to translate the player
- track camera overlay with transforms for smoother updates
- keep transforms synchronized during collision checks to prevent phasing

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b217c151c4832eac34cdb5c8c5fc73