### PR TITLE
Add per-platform drop-through timers for one-way solids

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,25 @@ Defines in‑level object types:
 - `InteractableObject` and `InteractableToggle`: elements that react to player interaction and can broadcast signals.
 - `Reciever`: shows different child elements based on received signals.
 - `Slope`: ramp geometry. Combine classes `object`, `solid` and `slope` and set `data-slope` to `up-right`, `up-left`, `down-right` or `down-left`.
+- `OneWaySolid`: blocks movement from one side. Use classes `object solid oneway-DIR` where `DIR` is `up`, `down`, `left` or `right`. Add `dropthrough` to an `oneway-up` element to allow falling through by holding `S` and pressing a jump key; each platform maintains its own drop timer.
 
 Example sloped surface:
 
 ```html
 <div class="object solid slope" data-slope="up-right"
      style="width:200px;height:200px;clip-path:polygon(0% 100%,100% 100%,100% 0%);"></div>
+```
+
+Example one-way platform:
+
+```html
+<div class="object solid oneway-up" style="width:100px;height:20px;"></div>
+```
+
+Example drop-through platform:
+
+```html
+<div class="object solid oneway-up dropthrough" style="width:100px;height:20px;"></div>
 ```
 
 Example toggle/receiver pair:

--- a/html/platformer.html
+++ b/html/platformer.html
@@ -57,7 +57,6 @@
                     </div>
                 </div>
                 <div class="object solid floor" id="floor-1"></div>
-                <div class="object solid oneway-up dropthrough" style="position: absolute;top: 70vh;left: 300px;width: 300px; height: 20px;background-color: green;"></div>
 
                 <div class="object solid" id="solidObject-1">
                     <div class="double-cap"></div>
@@ -141,6 +140,7 @@
                 <!-- <div class="solidObject" id="start-cap">
                     <div class="cap"></div>
                 </div> -->
+                <div class="object solid oneway-up dropthrough" style="position: absolute;top: 70vh;left: 300px;width: 300px; height: 20px;background-color: green;"></div>
                 <div class="object solid moving-platform moving-platform-y oneway-up dropthrough" id="moving-platform-1" style="width:100px;height:20px;top:350px;left:0px;background-color: yellow;"></div>
                 <div class="object solid moving-platform moving-platform-x oneway-up dropthrough" id="moving-platform-2" style="width:100px;height:20px;top:400px;left:0px;background-color: yellow;"></div>
             </div>

--- a/html/platformer.html
+++ b/html/platformer.html
@@ -57,7 +57,7 @@
                     </div>
                 </div>
                 <div class="object solid floor" id="floor-1"></div>
-                <div class="object solid oneway-up dropthrough" style="position: absolute;top: 70vh;left: 0px;width: 100px; height: 20px;background-color: green;"></div>
+                <div class="object solid oneway-up dropthrough" style="position: absolute;top: 70vh;left: 300px;width: 300px; height: 20px;background-color: green;"></div>
 
                 <div class="object solid" id="solidObject-1">
                     <div class="double-cap"></div>

--- a/js/collisionDetector.js
+++ b/js/collisionDetector.js
@@ -46,7 +46,6 @@ export class CollisionDetection {
     checkTriggerCollisions(object, collisionObjects) {
         const playerRect = object.element.getBoundingClientRect();
         collisionObjects.forEach(collisionObject => {
-            if (!collisionObject.enabled) return;
             const collisionRect = collisionObject.element.getBoundingClientRect();
             if (intersects(playerRect, collisionRect)) {
                 if (collisionObject.element.classList.contains('trigger')) {
@@ -60,7 +59,6 @@ export class CollisionDetection {
         const playerRect = object.element.getBoundingClientRect();
         let collisionCount = 0;
         collisionObjects.forEach(collisionObject => {
-            if (!collisionObject.enabled) return;
             if (collisionObject.element.classList.contains('trigger')) return;
             if (collisionObject.element.classList.contains('slope')) return;
             const collisionRect = collisionObject.element.getBoundingClientRect();
@@ -87,7 +85,6 @@ export class CollisionDetection {
         const playerRect = object.element.getBoundingClientRect();
         let collisionCount = 0;
         collisionObjects.forEach(collisionObject => {
-            if (!collisionObject.enabled) return;
             if (collisionObject.element.classList.contains('trigger')) return;
             if (collisionObject.element.classList.contains('slope')) return;
             const collisionRect = collisionObject.element.getBoundingClientRect();
@@ -114,7 +111,6 @@ export class CollisionDetection {
         const playerRect = object.element.getBoundingClientRect();
         let collisionCount = 0;
         collisionObjects.forEach(collisionObject => {
-            if (!collisionObject.enabled) return;
             if (!collisionObject.element.classList.contains('slope')) return;
             const slopeRect = collisionObject.element.getBoundingClientRect();
             if (!intersects(playerRect, slopeRect)) return;
@@ -160,7 +156,6 @@ export class CollisionDetection {
             bottom: playerRect.bottom + 1,
         };
         return collisionObjects.some(collisionObject => {
-            if (!collisionObject.enabled) return false;
             const el = collisionObject.element;
             if (!(el.classList.contains('solid') || el.classList.contains('slope'))) return false;
             return intersects(probeRect, el.getBoundingClientRect());

--- a/js/levelObjects.js
+++ b/js/levelObjects.js
@@ -110,17 +110,6 @@ export class MovingPlatform extends SolidObject {
 }
 
 export class OneWaySolidObject extends SolidObject {
-  constructor(element) {
-    super(element);
-    const dirClass = Array.from(element.classList).find((cls) =>
-      cls.startsWith("oneway-")
-    );
-    this.direction = dirClass ? dirClass.split("-")[1] : "up";
-    this.dropthrough = element.classList.contains("dropthrough");
-  }
-}
-
-export class OneWaySolidObject extends SolidObject {
     constructor(element) {
         super(element);
         const dirClass = Array.from(element.classList).find(cls => cls.startsWith('oneway-'));
@@ -129,26 +118,27 @@ export class OneWaySolidObject extends SolidObject {
         this.dropTimer = 0;
     }
 
-    update(player) {
+    update() {
         super.update();
         if (this.dropTimer > 0) this.dropTimer--;
 
         const rect = this.element.getBoundingClientRect();
-        const playerRect = player.element.getBoundingClientRect();
+        const playerRect = gameInstance.player.element.getBoundingClientRect();
+        const MARGIN = 1;
 
         let shouldEnable = true;
         switch (this.direction) {
             case 'up':
-                shouldEnable = playerRect.bottom <= rect.top && this.dropTimer === 0;
+                shouldEnable = playerRect.bottom <= (rect.top + MARGIN) && this.dropTimer === 0;
                 break;
             case 'down':
-                shouldEnable = playerRect.top >= rect.bottom;
+                shouldEnable = playerRect.top >= (rect.bottom - MARGIN);
                 break;
             case 'left':
-                shouldEnable = playerRect.right <= rect.left;
+                shouldEnable = playerRect.right <= (rect.left + MARGIN);
                 break;
             case 'right':
-                shouldEnable = playerRect.left >= rect.right;
+                shouldEnable = playerRect.left >= (rect.right - MARGIN);
                 break;
         }
         this.enabled = shouldEnable;

--- a/js/levelObjects.js
+++ b/js/levelObjects.js
@@ -65,6 +65,41 @@ export class SolidObject extends LevelObject{
     }
 }
 
+export class OneWaySolidObject extends SolidObject {
+    constructor(element) {
+        super(element);
+        const dirClass = Array.from(element.classList).find(cls => cls.startsWith('oneway-'));
+        this.direction = dirClass ? dirClass.split('-')[1] : 'up';
+        this.dropthrough = element.classList.contains('dropthrough');
+        this.dropTimer = 0;
+    }
+
+    update(player) {
+        super.update();
+        if (this.dropTimer > 0) this.dropTimer--;
+
+        const rect = this.element.getBoundingClientRect();
+        const playerRect = player.element.getBoundingClientRect();
+
+        let shouldEnable = true;
+        switch (this.direction) {
+            case 'up':
+                shouldEnable = playerRect.bottom <= rect.top && this.dropTimer === 0;
+                break;
+            case 'down':
+                shouldEnable = playerRect.top >= rect.bottom;
+                break;
+            case 'left':
+                shouldEnable = playerRect.right <= rect.left;
+                break;
+            case 'right':
+                shouldEnable = playerRect.left >= rect.right;
+                break;
+        }
+        this.enabled = shouldEnable;
+    }
+}
+
 export class TriggerArea extends LevelObject {
     constructor(element) {
         super(element);

--- a/js/levelObjects.js
+++ b/js/levelObjects.js
@@ -110,39 +110,42 @@ export class MovingPlatform extends SolidObject {
 }
 
 export class OneWaySolidObject extends SolidObject {
-    constructor(element) {
-        super(element);
-        const dirClass = Array.from(element.classList).find(cls => cls.startsWith('oneway-'));
-        this.direction = dirClass ? dirClass.split('-')[1] : 'up';
-        this.dropthrough = element.classList.contains('dropthrough');
-        this.dropTimer = 0;
+  constructor(element) {
+    super(element);
+    const dirClass = Array.from(element.classList).find((cls) =>
+      cls.startsWith("oneway-")
+    );
+    this.direction = dirClass ? dirClass.split("-")[1] : "up";
+    this.dropthrough = element.classList.contains("dropthrough");
+    this.dropTimer = 0;
+  }
+
+  update() {
+    super.update();
+    if (this.dropTimer > 0) this.dropTimer--;
+
+    const rect = this.element.getBoundingClientRect();
+    const playerRect = gameInstance.player.element.getBoundingClientRect();
+    const MARGIN = 1;
+
+    let shouldEnable = true;
+    switch (this.direction) {
+      case "up":
+        shouldEnable =
+          playerRect.bottom <= rect.top + MARGIN && this.dropTimer === 0;
+        break;
+      case "down":
+        shouldEnable = playerRect.top >= rect.bottom - MARGIN;
+        break;
+      case "left":
+        shouldEnable = playerRect.right <= rect.left + MARGIN;
+        break;
+      case "right":
+        shouldEnable = playerRect.left >= rect.right - MARGIN;
+        break;
     }
-
-    update() {
-        super.update();
-        if (this.dropTimer > 0) this.dropTimer--;
-
-        const rect = this.element.getBoundingClientRect();
-        const playerRect = gameInstance.player.element.getBoundingClientRect();
-        const MARGIN = 1;
-
-        let shouldEnable = true;
-        switch (this.direction) {
-            case 'up':
-                shouldEnable = playerRect.bottom <= (rect.top + MARGIN) && this.dropTimer === 0;
-                break;
-            case 'down':
-                shouldEnable = playerRect.top >= (rect.bottom - MARGIN);
-                break;
-            case 'left':
-                shouldEnable = playerRect.right <= (rect.left + MARGIN);
-                break;
-            case 'right':
-                shouldEnable = playerRect.left >= (rect.right - MARGIN);
-                break;
-        }
-        this.enabled = shouldEnable;
-    }
+    this.enabled = shouldEnable;
+  }
 }
 
 export class TriggerArea extends LevelObject {

--- a/js/objectFactory.js
+++ b/js/objectFactory.js
@@ -1,4 +1,4 @@
-import { SolidObject, InteractableObject, InteractableToggle, Reciever, LevelObject, TriggerArea } from "./levelObjects.js";
+import { SolidObject, InteractableObject, InteractableToggle, Reciever, LevelObject, TriggerArea, OneWaySolidObject } from "./levelObjects.js";
 
 const objectFactory = {
     solid: SolidObject,
@@ -11,6 +11,10 @@ const objectFactory = {
 
 export function createObject(element) {
     const classes = Array.from(element.classList);
+    const oneWayClass = classes.find(cls => cls.startsWith('oneway-'));
+    if (oneWayClass && classes.includes('solid')) {
+        return { type: 'solid', instance: new OneWaySolidObject(element) };
+    }
     let type = classes.find(cls => objectFactory[cls]);
 
     if (type === 'interactable' && classes.includes('toggle')) {

--- a/js/objectFactory.js
+++ b/js/objectFactory.js
@@ -6,36 +6,90 @@ const objectFactory = {
     reciever: Reciever,
     interactable: InteractableObject,
     'interactable-toggle': InteractableToggle,
-    plax: LevelObject
+    plax: LevelObject,
+    'moving-platform': MovingPlatform,
+    'oneway': OneWaySolidObject
+
 };
 
 export function createObject(element) {
     const classes = Array.from(element.classList);
-    if (classes.includes("moving-platform")) {
-        return { type: "solid", instance: new MovingPlatform(element) };
+
+    // Find all matching types
+    let types = classes.filter(cls => objectFactory[cls]);
+
+    // Special handling for interactable-toggle
+    if (types.includes('interactable') && classes.includes('toggle')) {
+        types = types.filter(t => t !== 'interactable');
+        types.push('interactable-toggle');
     }
+
     const oneWayClass = classes.find(cls => cls.startsWith('oneway-'));
-    if (oneWayClass && classes.includes('solid')) {
-        return { type: 'solid', instance: new OneWaySolidObject(element) };
-    }
-    let type = classes.find(cls => objectFactory[cls]);
-
-    if (type === 'interactable' && classes.includes('toggle')) {
-        type = 'interactable-toggle';
+    if (oneWayClass) {
+        if (!types.includes('oneway')) types.push('oneway');
     }
 
+    // Special handling for plax
     if (classes.includes('plax')) {
-        type = 'plax';
+        if (!types.includes('plax')) types.push('plax');
         const zClass = classes.find(cls => cls.startsWith('z'));
         if (zClass) {
             element.style.zIndex = zClass.substring(1);
         }
     }
 
-    const Constructor = objectFactory[type];
-    if (!Constructor) return null;
+    if (types.length === 0) return null;
 
-    return { type, instance: new Constructor(element) };
+    // Compose mixin object
+    let instance = {};
+    // Collect all update methods
+    const updateMethods = [];
+    // Call all constructors and copy their properties/methods
+    types.forEach(type => {
+        const Constructor = objectFactory[type];
+        if (Constructor) {
+            // Call constructor, bind properties/methods
+            const temp = new Constructor(element);
+            Object.getOwnPropertyNames(temp).forEach(key => {
+                instance[key] = temp[key];
+            });
+            // Also copy prototype methods
+            getAllPrototypeMethods(Constructor.prototype).forEach(key => {
+                if (key !== 'constructor') {
+                    if (key === 'update' && typeof Constructor.prototype[key] === 'function') {
+                        updateMethods.push(Constructor.prototype[key]);
+                    }
+                    instance[key] = Constructor.prototype[key].bind(instance);
+                }
+            });
+
+            
+        }
+    });
+
+    // Combine all update methods into one
+    if (updateMethods.length > 0) {
+        instance.update = function() {
+            updateMethods.forEach(fn => fn.call(this));
+        };
+    }
+    console.log(types)
+
+    return { types, instance };
+}
+
+function getAllPrototypeMethods(obj) {
+    const methods = new Set();
+    let proto = obj;
+    while (proto && proto !== Object.prototype) {
+        Object.getOwnPropertyNames(proto).forEach(name => {
+            if (typeof proto[name] === 'function' && name !== 'constructor') {
+                methods.add(name);
+            }
+        });
+        proto = Object.getPrototypeOf(proto);
+    }
+    return Array.from(methods);
 }
 
 export default objectFactory;

--- a/js/player.js
+++ b/js/player.js
@@ -4,6 +4,7 @@ import GifAnimationManager from "./gifAnimationManager.js";
 import { Physics } from "./physics.js";
 import { CollisionDetection } from "./collisionDetector.js";
 import InteractionBox from "./interactionBox.js";
+import { OneWaySolidObject } from "./levelObjects.js";
 
 export default class Player {
     constructor(element) {
@@ -165,8 +166,10 @@ export default class Player {
     }
 
     update() {
-
         this.processInput();
+        this.collisionObjects.forEach(obj => {
+            if (typeof obj.update === 'function') obj.update(this);
+        });
         this.physics.applyPhysics(this, this.collision.state);
 
         const steps = Math.ceil(Math.max(Math.abs(this.velocityX), Math.abs(this.velocityY)));
@@ -241,7 +244,19 @@ export default class Player {
         }
         if (gameInstance.keyState['S']) this.physics.move(this, 0, this.physics.acceleration);
         // Similar for other directions
-        if (gameInstance.keyState['W'] || gameInstance.keyState['SPACE']) {
+        if (gameInstance.keyState['S'] && (gameInstance.keyState['W'] || gameInstance.keyState['SPACE'])) {
+            this.collisionObjects.forEach(obj => {
+                if (obj instanceof OneWaySolidObject && obj.dropthrough && obj.direction === 'up') {
+                    const rect = obj.element.getBoundingClientRect();
+                    const playerRect = this.element.getBoundingClientRect();
+                    if (playerRect.bottom <= rect.top + 1 && playerRect.bottom >= rect.top - 5) {
+                        obj.dropTimer = 10;
+                    }
+                }
+            });
+            this.velocityY = Math.max(this.velocityY, 1);
+            this.jumpProcessed = true;
+        } else if (gameInstance.keyState['W'] || gameInstance.keyState['SPACE']) {
             this.jump();
         } else {
             this.jumpProcessed = false; // Reset the flag when 'W' is not pressed

--- a/js/player.js
+++ b/js/player.js
@@ -290,9 +290,9 @@ export default class Player {
         }
         if (gameInstance.keyState['S']) this.physics.move(this, 0, this.physics.acceleration);
         // Similar for other directions
-        if (gameInstance.keyState['S'] && (gameInstance.keyState['W'] || gameInstance.keyState['SPACE'])) {
+        if (gameInstance.keyState['S'] && (gameInstance.keyState['W'] || gameInstance.keyState['SPACE'])) { 
             this.collisionObjects.forEach(obj => {
-                if (obj instanceof OneWaySolidObject && obj.dropthrough && obj.direction === 'up') {
+                if (obj.element.classList.value.split(" ").filter(className => className.startsWith('oneway-')).length > 0 && obj.dropthrough && obj.direction === 'up') {
                     const rect = obj.element.getBoundingClientRect();
                     const playerRect = this.element.getBoundingClientRect();
                     if (playerRect.bottom <= rect.top + 1 && playerRect.bottom >= rect.top - 5) {

--- a/js/player.js
+++ b/js/player.js
@@ -215,9 +215,6 @@ export default class Player {
 
     update() {
         this.processInput();
-        this.collisionObjects.forEach(obj => {
-            if (typeof obj.update === 'function') obj.update(this);
-        });
         this.physics.applyPhysics(this, this.collision.state);
 
         const steps = Math.ceil(Math.max(Math.abs(this.velocityX), Math.abs(this.velocityY)));

--- a/js/screen.js
+++ b/js/screen.js
@@ -40,7 +40,7 @@ export default class Screen {
 
     getObjectsByTypes(...types) {
         return this.objects
-            .filter(obj => types.includes(obj.type))
+            .filter(obj => types.some(type => obj.types.includes(type)))
             .map(obj => obj.instance);
     }
 


### PR DESCRIPTION
## Summary
- move drop-through timer into each `OneWaySolidObject`
- have one-way solids disable themselves when the player is on the pass-through side
- update player logic to trigger platform drop timers and run object updates each frame

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/collisionDetector.js && node --check js/levelObjects.js && node --check js/objectFactory.js && node --check js/player.js`


------
https://chatgpt.com/codex/tasks/task_b_68aa49bb6534832e848a23c68a02c0c6