### PR TITLE
Add Node test runner and unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "NekkoPlat",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/test/inputManager.test.js
+++ b/test/inputManager.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import InputManager from '../js/inputManager.js';
+
+test('isActionActive reflects key states', () => {
+  global.document = { addEventListener: () => {} };
+  const manager = new InputManager({ jump: ['Space'] });
+  manager.activeKeys.set('Space', true);
+  assert.equal(manager.isActionActive('jump'), true);
+  manager.activeKeys.set('Space', false);
+  assert.equal(manager.isActionActive('jump'), false);
+});
+
+test('addKeyToAction and removeKeyFromAction manage bindings', () => {
+  global.document = { addEventListener: () => {} };
+  const manager = new InputManager();
+  manager.bindAction('shoot', ['KeyS']);
+  manager.addKeyToAction('shoot', 'KeyF');
+  manager.activeKeys.set('KeyF', true);
+  assert.equal(manager.isActionActive('shoot'), true);
+  manager.removeKeyFromAction('shoot', 'KeyF');
+  assert.equal(manager.isActionActive('shoot'), false);
+});

--- a/test/physics.test.js
+++ b/test/physics.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Physics } from '../js/physics.js';
+
+test('applyPhysics zeroes small horizontal velocity when grounded', () => {
+  const physics = new Physics();
+  const obj = { velocityX: 0.1, velocityY: 0, grounded: true };
+  physics.applyPhysics(obj, { bottom: 0 });
+  assert.equal(obj.velocityX, 0);
+});
+
+test('applyPhysics applies friction and limits vertical speed', () => {
+  const physics = new Physics();
+  const obj = { velocityX: 5, velocityY: 50, grounded: true };
+  physics.applyPhysics(obj, { bottom: 0 });
+  assert.equal(obj.velocityX, 5 * physics.friction);
+  assert.equal(obj.velocityY, 30); // falling speed capped
+});
+
+test('applyPhysics clamps horizontal velocity to max', () => {
+  const physics = new Physics();
+  const obj = { velocityX: 20, velocityY: 0, grounded: false };
+  physics.applyPhysics(obj, { bottom: 0 });
+  assert.equal(obj.velocityX, physics.maxVelocity);
+});
+
+test('move applies different horizontal acceleration when airborne', () => {
+  const physics = new Physics();
+  const grounded = { velocityX: 0, velocityY: 0, grounded: true };
+  physics.move(grounded, 2, 3);
+  assert.equal(grounded.velocityX, 2);
+  assert.equal(grounded.velocityY, 3);
+
+  const airborne = { velocityX: 0, velocityY: 0, grounded: false };
+  physics.move(airborne, 2, 3);
+  assert.equal(airborne.velocityX, 1); // half when airborne
+  assert.equal(airborne.velocityY, 3);
+});


### PR DESCRIPTION
## Summary
- set up basic Node testing via `node --test`
- add unit tests for Physics movement and velocity clamping
- add unit tests for InputManager bindings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b7b9408a58832e90cbbc5eb301180f